### PR TITLE
Support ARM_SMULWB in the ARM scanner

### DIFF
--- a/scanner_arm.c
+++ b/scanner_arm.c
@@ -1533,6 +1533,14 @@ size_t scan_arm(dbm_thread *thread_data, uint32_t *read_address, int basic_block
         break;
       }
 
+      case ARM_SMULWB: {
+        uint32_t rd, rn, rm;
+        arm_smulwb_decode_fields(read_address, &rd, &rn, &rm);
+        assert(rd != pc && rn != pc && rm != pc);
+        copy_arm();
+        break;
+      }
+
       case ARM_RBIT: {
         uint32_t rd, rm;
         arm_rbit_decode_fields(read_address, &rd, &rm);


### PR DESCRIPTION
Technically, this may be integrated with the SMULBB and SMULTT case statements, but I thought I would just create a new case statement because SMULWB does not belong in the SMULBB/SMULTT group.

ARM_SMULWB is used in the Android 4.1 version of libjpeg. See: [armv6-idct.S](https://android.googlesource.com/platform/external/jpeg/+/android-4.1.1_r1.1/armv6_idct.S).

If you have any comments, please do let me know so that I may improve the quality of my commits and pull requests. Thank you!
