### PR TITLE
ARM: Support pre-ARMv7 data memory barrier MCR operation

### DIFF
--- a/scanner_arm.c
+++ b/scanner_arm.c
@@ -1143,6 +1143,14 @@ size_t scan_arm(dbm_thread *thread_data, uint32_t *read_address, int basic_block
         // This is used in OpenSSL in OPENSSL_cpuid_setup, a constructor. WTF
         } else if (coproc == 15 && opc1 == 0 && crn == 9 && crm == 13 && opc2 == 0 && load_store == 1 && rd != pc) {
           copy_arm();
+
+        // Data memory barrier operation, deprecated in ARMv7-a in favor of
+        // dmb(). This is used in Raspbian Jessie's libc6, which is apparently
+        // compiled for ARMv6 due to compatibility reasons. Section B3.12.33 in
+        // page B3-136 of ARM DDI 0406B has more information on this mcr op.
+        } else if (coproc == 15 && opc1 == 0 && crn == 7 && crm == 10 && opc2 == 5 && load_store == 0 && rd != pc) {
+          copy_arm();
+
         } else {
           fprintf(stderr, "unknown coproc: %d %d %d %d %d %d\n", opc1, crn, rd, coproc, opc2, crm);
           while(1);


### PR DESCRIPTION
Hello,

I was running MAMBO on the Raspberry Pi 3, running Raspbian Jessie, when I encountered the following instruction in libc6:

```asm
ee070fba        mcr     15, 0, r0, cr7, cr10, 5
```

This is a data memory barrier operation, which is deprecated in ARMv7-a in favor of `dmb`. However, Raspbian Jessie is compiled for ARMv6, which is why I think this is used instead. Hopefully the following PR is acceptable but let me know if you wanted more details. Thanks!