### PR TITLE
Allow the use of the zero register in CB(N)Z/ TB(N)Z branches

### DIFF
--- a/scanner_a64.c
+++ b/scanner_a64.c
@@ -303,7 +303,6 @@ void a64_branch_imm_reg(dbm_thread *thread_data, uint32_t **o_write_p,
   *write_p = NOP;
   write_p++;
 
-  assert(rt != sp);
   a64_branch_save_context(&write_p);
 
   cbz_branch = write_p++;


### PR DESCRIPTION
The existing `assert(rt != sp);` prevents conditional branches (`CB(N)Z`/`TB(N)Z`) from using the zero register.  The `sp` register in these intructions is actually interpreted as register 31 (`WRZ` and `XZR`).
Although these kind of branches are silly they have been observed in the wild (e.g. produced by an LLVM compiler; see ghdl/ghdl#667).
