### PR TITLE
Allow to change -Ttext-segment with an envvar

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ OPTS+=-DDBM_TRACES #-DTB_AS_TRACE_HEAD #-DBLXI_AS_TRACE_HEAD
 CFLAGS=-D_GNU_SOURCE -g -std=gnu99 -O2
 #CFLAGS+=-mcpu=native
 
-LDFLAGS=-static -ldl -Wl,-Ttext-segment=0xa8000000
+LDFLAGS=-static -ldl -Wl,-Ttext-segment=$(or $(TEXT_SEGMENT),0xa8000000)
 LIBS=-lelf -lpthread
 HEADERS=*.h makefile
 INCLUDES=-I/usr/include/libelf


### PR DESCRIPTION
With this PR, if `TEXT_SEGMENT` is defined, it will be used to set `-Ttext-segment`. Otherwise, it will default to `-Ttext-segment=0xa8000000`.

Related to #31 and #32, this allows to build on Raspbian with e.g. `TEXT_SEGMENT='0x78000000' CFLAGS='-mcpu=cotex-a53' make clean all`.