### PR TITLE
makefile: add PLUGIN_ARGS

### DIFF
--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ pie:
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 dbm: $(HEADERS) $(SOURCES) $(PLUGINS)
-	$(CC) $(CFLAGS) $(LDFLAGS) $(OPTS) $(INCLUDES) -o $@ $(SOURCES) $(PLUGINS) $(PIE) $(LIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $(OPTS) $(INCLUDES) -o $@ $(SOURCES) $(PLUGINS) $(PIE) $(LIBS) $(PLUGIN_ARGS)
 
 clean:
 	rm -f dbm elf_loader/elf_loader.o


### PR DESCRIPTION
This PR allows to add flags to the dbm build target through envvar PLUGIN_ARGS. This is required when plugins depend on additional pre-built objects.