### PR TITLE
Various API helper functions ported to RISC-V, along with callback support and branch printing plugins

### DIFF
--- a/api/branch_decoder_support.c
+++ b/api/branch_decoder_support.c
@@ -3,7 +3,7 @@
       https://github.com/beehive-lab/mambo
 
   Copyright 2016 Cosmin Gorgovan <cosmin at linux-geek dot org>
-  Copyright 2017 The University of Manchester
+  Copyright 2017-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,8 +34,63 @@
   #include "../pie/pie-a64-decoder.h"
   #include "../pie/pie-a64-field-decoder.h"
 #endif
+#ifdef __riscv
+  #include "../pie/pie-riscv-decoder.h"
+  #include "../pie/pie-riscv-field-decoder.h"
+#endif
 
 #ifdef PLUGINS_NEW
+
+#ifdef __riscv
+mambo_branch_type __get_riscv_branch_type(mambo_context *ctx) {
+  mambo_branch_type type = BRANCH_NONE;
+  switch (ctx->code.inst) {
+    case RISCV_BEQ:
+    case RISCV_BNE:
+    case RISCV_BLT:
+    case RISCV_BGE:
+    case RISCV_BLTU:
+    case RISCV_BGEU:
+    case RISCV_C_BEQZ:
+    case RISCV_C_BNEZ:
+      type = BRANCH_DIRECT | RISCV_BRANCH | BRANCH_COND;
+      break;
+
+    case RISCV_C_J:
+      type = BRANCH_DIRECT | RISCV_JUMP;
+      break;
+
+    case RISCV_C_JAL:
+    case RISCV_JAL:
+      type = BRANCH_DIRECT | RISCV_JUMP | BRANCH_CALL;
+      break;
+
+    case RISCV_C_JR:
+      unsigned int rs1;
+      riscv_c_jr_decode_fields(ctx->code.read_address, &rs1);
+      type = BRANCH_INDIRECT | RISCV_JUMP;
+      if (rs1 == ra)
+        type |= BRANCH_RETURN;
+      break;
+
+    case RISCV_JALR: {
+      type = BRANCH_INDIRECT | RISCV_JUMP;
+      unsigned int rd, rs1, imm;
+      riscv_jalr_decode_fields(ctx->code.read_address, &rd, &rs1, &imm);
+      if (rs1 == ra)
+        type |= BRANCH_RETURN;
+      else 
+        type |= BRANCH_CALL;
+      break;
+    }
+    case RISCV_C_JALR: {
+    type = BRANCH_INDIRECT | RISCV_JUMP | BRANCH_CALL;
+      break;
+    }
+  }
+  return type;
+}
+#endif //riscv
 
 #ifdef __arm__
 mambo_branch_type __get_thumb_branch_type(mambo_context *ctx) {
@@ -211,19 +266,9 @@ mambo_branch_type __get_arm_branch_type(mambo_context *ctx) {
 }
 #endif // __arm__
 
-mambo_branch_type mambo_get_branch_type(mambo_context *ctx) {
-  mambo_branch_type type;
-
-#ifdef __arm__
-  if (mambo_get_inst_type(ctx) == THUMB_INST) {
-   type = __get_thumb_branch_type(ctx);
-  } else { // ARM
-    type = __get_arm_branch_type(ctx);
-  }
-#endif
-#ifdef __aarch64__
-  type = BRANCH_NONE;
-
+#ifdef __aarch64
+mambo_branch_type __get_aarch64_branch_type(mambo_context *ctx) {
+  mambo_branch_type type = BRANCH_NONE;
   switch (ctx->code.inst) {
     case A64_CBZ_CBNZ:
       type = BRANCH_DIRECT | BRANCH_COND | BRANCH_COND_CBZ;
@@ -254,6 +299,26 @@ mambo_branch_type mambo_get_branch_type(mambo_context *ctx) {
       break;
     }
   }
+}
+#endif
+
+mambo_branch_type mambo_get_branch_type(mambo_context *ctx) {
+  mambo_branch_type type;
+
+#ifdef __arm__
+  if (mambo_get_inst_type(ctx) == THUMB_INST) {
+   type = __get_thumb_branch_type(ctx);
+  } else { // ARM
+    type = __get_arm_branch_type(ctx);
+  }
+#endif
+
+#ifdef __riscv
+   type = __get_riscv_branch_type(ctx);
+#endif
+
+#ifdef __aarch64__
+  type = __get_aarch64_branch_type(ctx);
 #endif // __aarch64__
 
   return type;

--- a/api/helpers.c
+++ b/api/helpers.c
@@ -31,6 +31,7 @@
 #include "../api/emit_a64.h"
 #elif __riscv
 #include "../pie/pie-riscv-encoder.h"
+#include "../api/emit_riscv.h"
 #endif
 
 #define not_implemented() \

--- a/api/helpers.h
+++ b/api/helpers.h
@@ -3,7 +3,7 @@
       https://github.com/beehive-lab/mambo
 
   Copyright 2013-2016 Cosmin Gorgovan <cosmin at linux-geek dot org>
-  Copyright 2017-2020 The University of Manchester
+  Copyright 2017-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,6 +32,8 @@ typedef struct {
 #ifdef __arm__
   #define MAX_FCALL_ARGS 4
 #elif __aarch64__
+  #define MAX_FCALL_ARGS 8
+#elif __riscv
   #define MAX_FCALL_ARGS 8
 #endif
 

--- a/api/plugin_support.c
+++ b/api/plugin_support.c
@@ -3,7 +3,7 @@
       https://github.com/beehive-lab/mambo
 
   Copyright 2013-2016 Cosmin Gorgovan <cosmin at linux-geek dot org>
-  Copyright 2017-2020 The University of Manchester
+  Copyright 2017-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -118,6 +118,8 @@ int mambo_register_function_cb(mambo_context *ctx, char *fn_name,
 #ifdef __arm__
   #define ARG_LIMIT 4
 #elif __aarch64__
+  #define ARG_LIMIT 8
+#elif __riscv
   #define ARG_LIMIT 8
 #endif
   if (cb_pre == NULL && cb_post == NULL) return -1;
@@ -401,9 +403,11 @@ int mambo_add_identity_mapping(mambo_context *ctx) {
   }
 
   uintptr_t addr = (uintptr_t)mambo_get_cc_addr(ctx);
+#ifdef __arm__
   if (ctx->code.inst_type == THUMB_INST) {
     addr |= THUMB;
   }
+#endif
 
   int ret = hash_add(&current_thread->entry_address, addr, addr);
   return (ret) ? 0 : -1;

--- a/api/plugin_support.h
+++ b/api/plugin_support.h
@@ -3,7 +3,7 @@
       https://github.com/beehive-lab/mambo
 
   Copyright 2013-2016 Cosmin Gorgovan <cosmin at linux-geek dot org>
-  Copyright 2017-2020 The University of Manchester
+  Copyright 2017-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -108,6 +108,8 @@ typedef enum {
   BRANCH_CALL = (1 << 9),
   BRANCH_INTERWORKING = (1 << 10), // A32 and T32
   BRANCH_TABLE = (1 << 11),        // T32-only
+  RISCV_BRANCH = (1 << 12), // RISCV only
+  RISCV_JUMP = (1 << 13), //RISCV only
 } mambo_branch_type;
 
 typedef struct {

--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -3,7 +3,7 @@
       https://github.com/beehive-lab/mambo
 
   Copyright 2020 Guillermo Callaghan <guillermocallaghan at hotmail dot com>
-  Copyright 2020 The University of Manchester
+  Copyright 2020-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 #include "dbm.h"
 #include "scanner_common.h"
+#include "../../api/helpers.h"
 
 #define MIN_FSPACE 56
 #define BRANCH_FSPACE 96
@@ -479,18 +480,6 @@ void riscv_cond_branch(dbm_thread *thread_data, uint16_t *read_address,
   *o_write_p = write_p;
 }
 
-bool riscv_scanner_deliver_callbacks(dbm_thread *thread_data, mambo_cb_idx cb_id,
-                                     uint16_t **o_read_address, riscv_instruction inst,
-                                     uint16_t **o_write_p, uint32_t **o_data_p,
-                                     int const basic_block, cc_type type,
-                                     bool allow_write, bool *stop) {
-#ifdef PLUGINS_NEW
-    // TODO: (riscv) PLUGINS_NEW
-    #error "PLUGINS not implemented"
-#endif
-  return false;
-}
-
 void riscv_check_free_space(dbm_thread *thread_data, uint16_t **write_p,
                           uint32_t **data_p, uint32_t size, int cur_block) {
   int basic_block;
@@ -507,6 +496,82 @@ void riscv_check_free_space(dbm_thread *thread_data, uint16_t **write_p,
     *data_p = (uint32_t *)&thread_data->code_cache->blocks[basic_block];
     *data_p += BASIC_BLOCK_SIZE;
   }
+}
+
+bool riscv_scanner_deliver_callbacks(dbm_thread *thread_data, mambo_cb_idx cb_id,
+                                     uint16_t **o_read_address, riscv_instruction inst,
+                                     uint16_t **o_write_p, uint32_t **o_data_p,
+                                     int const basic_block, cc_type type,
+                                     bool allow_write, bool *stop) {
+
+  bool replaced = false;
+#ifdef PLUGINS_NEW
+    if (global_data.free_plugin > 0) {
+    uint16_t *write_p = *o_write_p;
+    uint32_t *data_p = *o_data_p;
+    uint16_t *read_address = *o_read_address;
+
+    mambo_cond cond = AL;
+
+    mambo_context ctx;
+    set_mambo_context_code(&ctx, thread_data, cb_id, type, basic_block, RISCV_INST, inst, cond, read_address, write_p, data_p, stop);
+
+    for (int i = 0; i < global_data.free_plugin; i++) {
+      if (global_data.plugins[i].cbs[cb_id] != NULL) {
+        ctx.code.write_p = write_p;
+        ctx.code.data_p = data_p;
+        ctx.plugin_id = i;
+        ctx.code.replace = false;
+        ctx.code.available_regs = ctx.code.pushed_regs;
+        global_data.plugins[i].cbs[cb_id](&ctx);
+        if (allow_write) {
+          if (replaced && (write_p != ctx.code.write_p || ctx.code.replace)) {
+            fprintf(stderr, "MAMBO API WARNING: plugin %d added code for overridden"
+                            "instruction (%p).\n", i, read_address);
+          }
+          if (ctx.code.replace) {
+            if (cb_id == PRE_INST_C) {
+              replaced = true;
+            } else {
+              fprintf(stderr, "MAMBO API WARNING: plugin %d set replace_inst for "
+                              "a disallowed event (at %p).\n", i, read_address);
+            }
+          }
+          assert(count_bits(ctx.code.pushed_regs) == ctx.code.plugin_pushed_reg_count);
+          if (allow_write && ctx.code.pushed_regs) {
+            emit_pop(&ctx, ctx.code.pushed_regs);
+          }
+          write_p = ctx.code.write_p;
+          data_p = ctx.code.data_p;
+          riscv_check_free_space(thread_data, &write_p, &data_p, MIN_FSPACE, basic_block);
+        } else {
+          assert(ctx.code.write_p == write_p);
+          assert(ctx.code.data_p == data_p);
+        }
+      }
+    }
+
+    if (cb_id == PRE_BB_C) {
+      watched_functions_t *wf = &global_data.watched_functions;
+      for (int i = 0; i < wf->funcp_count; i++) {
+        if (read_address == wf->funcps[i].addr) {
+          _function_callback_wrapper(&ctx, wf->funcps[i].func);
+          if (ctx.code.replace) {
+            read_address = ctx.code.read_address;
+          }
+          write_p = ctx.code.write_p;
+          data_p = ctx.code.data_p;
+          riscv_check_free_space(thread_data, &write_p, &data_p, MIN_FSPACE, basic_block);
+        }
+      }
+    }
+
+    *o_write_p = write_p;
+    *o_data_p = data_p;
+    *o_read_address = read_address;
+  }
+#endif
+  return replaced;
 }
 
 size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
@@ -554,8 +619,6 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
     debug("  instruction word: 0x%x\n", *read_address);
 
 #ifdef PLUGINS_NEW
-    // TODO: (riscv) PLUGINS_NEW
-    #error "PLUGINS not implemented"
     bool skip_inst = riscv_scanner_deliver_callbacks(thread_data, PRE_INST_C, &read_address, inst,
                                                    &write_p, &data_p, basic_block, type, true, &stop);
     if (!skip_inst) {
@@ -911,6 +974,8 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
     if (!stop) {
       riscv_check_free_space(thread_data, &write_p, &data_p, MIN_FSPACE, basic_block);
     }
+
+    riscv_scanner_deliver_callbacks(thread_data, POST_INST_C, &read_address, inst, &write_p, &data_p, basic_block, type, !stop, &stop);
 
     if (inst < RISCV_LUI) {
       read_address++;

--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -28,7 +28,7 @@
 #include "../../api/helpers.h"
 
 #define MIN_FSPACE 56
-#define BRANCH_FSPACE 96
+#define BRANCH_FSPACE 112
 
 //#define DEBUG
 #ifdef DEBUG

--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -713,6 +713,7 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
           riscv_jal_decode_fields(read_address, &rd, &imm);
           const intptr_t offset = riscv_decode_j_imm(imm);
           const uintptr_t target = (uintptr_t)read_address + offset;
+          riscv_check_free_space(thread_data, &write_p, &data_p, BRANCH_FSPACE, basic_block);
           riscv_jump(thread_data, read_address, inst, basic_block, &write_p, rd, target);
 
           stop = true;

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@
 #PLUGINS+=plugins/strace.c
 #PLUGINS+=plugins/symbol_example.c
 #PLUGINS+=plugins/memcheck/memcheck.S plugins/memcheck/memcheck.c plugins/memcheck/naive_stdlib.c
+#PLUGINS+=plugins/cnd_branch_print.c
 
 OPTS= -DDBM_LINK_UNCOND_IMM
 OPTS+=-DDBM_INLINE_UNCOND_IMM

--- a/makefile
+++ b/makefile
@@ -9,6 +9,7 @@
 #PLUGINS+=plugins/symbol_example.c
 #PLUGINS+=plugins/memcheck/memcheck.S plugins/memcheck/memcheck.c plugins/memcheck/naive_stdlib.c
 #PLUGINS+=plugins/cnd_branch_print.c
+#PLUGINS+=plugins/uncnd_branch_print.c
 
 OPTS= -DDBM_LINK_UNCOND_IMM
 OPTS+=-DDBM_INLINE_UNCOND_IMM

--- a/makefile
+++ b/makefile
@@ -51,7 +51,7 @@ ifeq ($(ARCH),aarch64)
 	SOURCES += api/emit_a64.c
 endif
 ifeq ($(ARCH), riscv64)
-  # HEADERS += api/emit_riscv.h
+    HEADERS += api/emit_riscv.h
 	LDFLAGS += -Wl,-Ttext-segment=$(or $(TEXT_SEGMENT),0x7f000000)
 	PIE += pie/pie-riscv-field-decoder.o
 	PIE += pie/pie-riscv-encoder.o

--- a/plugins/cnd_branch_print.c
+++ b/plugins/cnd_branch_print.c
@@ -1,0 +1,72 @@
+/*
+  This file is part of MAMBO, a low-overhead dynamic binary modification tool:
+      https://github.com/beehive-lab/mambo
+
+  Copyright 2021 The University of Manchester
+  
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifdef PLUGINS_NEW
+
+#include <stdio.h>
+#include <assert.h>
+#include <locale.h>
+#include <inttypes.h>
+#include "../plugins.h"
+
+int cnd_branch_print_pre_thread_handler(mambo_context *ctx) {
+  uint64_t *cnd_br_count = mambo_alloc(ctx, sizeof(uint64_t));
+  *cnd_br_count = 0;
+  assert(cnd_br_count != NULL);
+  mambo_set_thread_plugin_data(ctx, cnd_br_count);
+  return 0;
+}
+
+// Called when a thread exits, or in all threads when the process exits
+int cnd_branch_print_post_thread_handler(mambo_context *ctx) {
+  uint64_t *cnd_br_count = mambo_get_thread_plugin_data(ctx);
+  fprintf(stderr, "%'lu conditional branches executed in thread %d\n", *cnd_br_count, mambo_get_thread_id(ctx));
+  mambo_free(ctx, cnd_br_count);
+  return 0;
+}
+
+int cnd_branch_print_pre_inst_handler(mambo_context *ctx) {
+  uint64_t *counter = mambo_get_thread_plugin_data(ctx);
+
+  mambo_branch_type type = mambo_get_branch_type(ctx);
+  if (type & BRANCH_COND) {
+    emit_counter64_incr(ctx, counter, 1);
+  }
+  return 0;
+}
+
+int cnd_branch_print_post_inst_handler(mambo_context *ctx) {
+  mambo_branch_type type = mambo_get_branch_type(ctx);
+  if (type & BRANCH_COND) {
+    fprintf(stderr, "RISCV conditional branch: read_addr: %p, target: 0x%ld\n", mambo_get_source_addr(ctx), ctx->thread_data->code_cache_meta[mambo_get_fragment_id(ctx)].branch_taken_addr);
+  }
+  return 0;
+}
+
+__attribute__((constructor)) void cnd_branch_print_init_plugin() {
+  mambo_context *ctx = mambo_register_plugin();
+  assert(ctx != NULL);
+
+  mambo_register_post_inst_cb(ctx, &cnd_branch_print_post_inst_handler);
+  mambo_register_pre_inst_cb(ctx, &cnd_branch_print_pre_inst_handler);
+  mambo_register_pre_thread_cb(ctx, &cnd_branch_print_pre_thread_handler);
+  mambo_register_post_thread_cb(ctx, &cnd_branch_print_post_thread_handler);
+
+  setlocale(LC_NUMERIC, "");
+}
+
+#endif

--- a/plugins/uncnd_branch_print.c
+++ b/plugins/uncnd_branch_print.c
@@ -1,0 +1,71 @@
+/*
+  This file is part of MAMBO, a low-overhead dynamic binary modification tool:
+      https://github.com/beehive-lab/mambo
+
+  Copyright 2021 The University of Manchester
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#ifdef PLUGINS_NEW
+
+#include <stdio.h>
+#include <assert.h>
+#include <locale.h>
+#include <inttypes.h>
+#include "../plugins.h"
+
+int uncnd_branch_print_pre_thread_handler(mambo_context *ctx) {
+  uint64_t *uncnd_br_count = mambo_alloc(ctx, sizeof(uint64_t));
+  *uncnd_br_count = 0;
+  assert(uncnd_br_count != NULL);
+  mambo_set_thread_plugin_data(ctx, uncnd_br_count);
+  return 0;
+}
+
+// Called when a thread exits, or in all threads when the process exits
+int uncnd_branch_print_post_thread_handler(mambo_context *ctx) {
+  uint64_t *uncnd_br_count = mambo_get_thread_plugin_data(ctx);
+  fprintf(stderr, "%'lu unconditional branches executed in thread %d\n", *uncnd_br_count, mambo_get_thread_id(ctx));
+  mambo_free(ctx, uncnd_br_count);
+  return 0;
+}
+
+int uncnd_branch_print_pre_inst_handler(mambo_context *ctx) {
+  uint64_t *counter = mambo_get_thread_plugin_data(ctx);
+  mambo_branch_type type = mambo_get_branch_type(ctx);
+  if (!(type & BRANCH_COND || type & BRANCH_NONE)) {
+    emit_counter64_incr(ctx, counter, 1);
+  }
+  return 0;
+}
+
+int uncnd_branch_print_post_inst_handler(mambo_context *ctx) {
+  mambo_branch_type type = mambo_get_branch_type(ctx);
+  if (!(type & BRANCH_COND || type & BRANCH_NONE)) {
+    fprintf(stderr, "RISCV unconditional branch: read_addr: %p, target: 0x%ld, branch type: %d\n", mambo_get_source_addr(ctx), ctx->thread_data->code_cache_meta[mambo_get_fragment_id(ctx)].branch_taken_addr, ctx->code.inst);
+  }
+  return 0;
+}
+
+__attribute__((constructor)) void uncnd_branch_print_init_plugin() {
+  mambo_context *ctx = mambo_register_plugin();
+  assert(ctx != NULL);
+
+  mambo_register_post_inst_cb(ctx, &uncnd_branch_print_post_inst_handler);
+  mambo_register_pre_inst_cb(ctx, &uncnd_branch_print_pre_inst_handler);
+  mambo_register_pre_thread_cb(ctx, &uncnd_branch_print_pre_thread_handler);
+  mambo_register_post_thread_cb(ctx, &uncnd_branch_print_post_thread_handler);
+
+  setlocale(LC_NUMERIC, "");
+}
+
+#endif 

--- a/scanner_public.h
+++ b/scanner_public.h
@@ -4,7 +4,7 @@
 
   Copyright 2013-2016 Cosmin Gorgovan <cosmin at linux-geek dot org>
   Copyright 2015-2020 Guillermo Callaghan <guillermocallaghan at hotmail dot com>
-  Copyright 2017-2020 The University of Manchester
+  Copyright 2017-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -468,6 +468,7 @@ void copy_to_reg_32bit(uint16_t **write_p, enum reg reg, uint32_t value);
 #ifdef __riscv
 void riscv_push(uint16_t **o_write_p, uint32_t regs);
 void riscv_pop(uint16_t **o_write_p, uint32_t regs);
+void riscv_copy_to_reg(uint16_t **write_p, const enum reg reg, uintptr_t const value);
 #endif
 
 void init_plugin();

--- a/util.S
+++ b/util.S
@@ -3,7 +3,7 @@
       https://github.com/beehive-lab/mambo
 
   Copyright 2013-2016 Cosmin Gorgovan <cosmin at linux-geek dot org>
-  Copyright 2017-2020 The University of Manchester
+  Copyright 2017-2021 The University of Manchester
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -263,7 +263,11 @@ retry:
   CBNZ W3, atomic_increment_u64
   MOV X0, X2
   RET
-
+#elif __riscv
+  #ifdef __riscv_atomic
+    amoadd.d a2, a1, (a0)
+    jr ra
+  #endif
 #endif
 .endfunc
 


### PR DESCRIPTION
I have included the increased size of BRANCH_FSPACE as well as the plugins, since this allows the plugins to run correctly