### PR TITLE
readme/Plugin API: adding PLUGINS_NEW explicitly is not required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Plugin API
 
 The plugin API is event-driven. Plugins should use a init function with `__attribute__((constructor))` to register themselves using `mambo_register_plugin()`. Once a plugin is registered, it can install callbacks for various events using the `mambo_register_*_cb()` functions. Callback-related functions are listed in `api/plugin_support.h`. Code generation functions are listed in `api/emit_<INST SET>.h` and code generation helpers are listed in `api/helpers.h`. You can also inspect the sample plugin in the `plugins/` directory.
 
-To build MAMBO with plugin support, uncomment the `-DPLUGINS_NEW` CFLAG in the `makefile`. Then, the source code or object file(s) of the plugin you're trying to build must be added to the `PLUGINS=` line in the `makefile`. Note that multiple plugins can be enabled at the same time (and will work correctly if properly designed). For performance reasons, it is recommended to remove unused plugins from the `PLUGINS=` list.
+To build MAMBO with plugin support, the source code or object file(s) of the plugin you're trying to build must be added to the `PLUGINS=` line in the `makefile`, or provided as an argument/envvar. Note that multiple plugins can be enabled at the same time (and will work correctly if properly designed). For performance reasons, it is recommended to remove unused plugins from the `PLUGINS=` list.
 
 
 Known issues


### PR DESCRIPTION
Since https://github.com/beehive-lab/mambo/commit/9f27d68a7739ef6f1cb36c06ca0b8b289238398e#diff-beda42571c095172ab63437d050612a571d0d9ddd3ad4f2aecbce907a9b7e3d0R44, PLUGINS_NEW is set by default if PLUGINS is defined. Therefore, it is not required to set it explicitly. This PR updates the README accordingly.