### PR TITLE
plugins/symbol_example: fix compiler warnings

### DIFF
--- a/plugins/symbol_example.c
+++ b/plugins/symbol_example.c
@@ -34,8 +34,8 @@ void se_print(size_t size, uintptr_t at, uintptr_t caller) {
   get_symbol_info_by_addr(at, &at_name, NULL, NULL);
   get_symbol_info_by_addr(caller, &caller_name, NULL, NULL);
 
-  printf("malloc(%d) at %p (%s)\n", size, at, at_name);
-  printf("  called from %p (%s)\n", caller, caller_name);
+  printf("malloc(%zu) at %p (%s)\n", size, (void*)at, at_name);
+  printf("  called from %p (%s)\n", (void*)caller, caller_name);
 }
 
 int se_hook(mambo_context *ctx) {

--- a/plugins/symbol_example.c
+++ b/plugins/symbol_example.c
@@ -20,6 +20,7 @@
 #include <sys/mman.h>
 #include <assert.h>
 #include <dlfcn.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/auxv.h>
@@ -34,8 +35,8 @@ void se_print(size_t size, uintptr_t at, uintptr_t caller) {
   get_symbol_info_by_addr(at, &at_name, NULL, NULL);
   get_symbol_info_by_addr(caller, &caller_name, NULL, NULL);
 
-  printf("malloc(%zu) at %p (%s)\n", size, (void*)at, at_name);
-  printf("  called from %p (%s)\n", (void*)caller, caller_name);
+  printf("malloc(%zu) at %" PRIxPTR "(%s)\n", size, at, at_name);
+  printf("  called from %" PRIxPTR "(%s)\n", caller, caller_name);
 }
 
 int se_hook(mambo_context *ctx) {


### PR DESCRIPTION
This PR fixes some minor compiler warnings when printing content without proper casting.