### PR TITLE
makefile: set GIT_VERSION to <nogit>, when git is not available

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ OPTS+=-DDBM_TRACES #-DTB_AS_TRACE_HEAD #-DBLXI_AS_TRACE_HEAD
 #OPTS+=-DCC_HUGETLB -DMETADATA_HUGETLB
 
 CFLAGS+=-D_GNU_SOURCE -g -std=gnu99 -O2
-CFLAGS+=-DGIT_VERSION=\"$(shell git describe --abbrev=8 --dirty --always)\"
+CFLAGS+=-DGIT_VERSION=\"$(shell git describe --abbrev=8 --dirty --always || echo '\<nogit\>')\"
 
 LDFLAGS+=-static -ldl
 LIBS=-lelf -lpthread -lz


### PR DESCRIPTION
This makes it explicit that the version could not be retrieved at runtime because there was not git available on the environment (PATH).