### PR TITLE
readme/Plugin API: add links to local resources, introduce PLUGIN_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Tip: When an application running under MAMBO exits, the string `We're done; exit
 Plugin API
 ----------
 
-The plugin API is event-driven. Plugins should use a init function with `__attribute__((constructor))` to register themselves using `mambo_register_plugin()`. Once a plugin is registered, it can install callbacks for various events using the `mambo_register_*_cb()` functions. Callback-related functions are listed in [`api/plugin_support.h`](api/plugin_support.h). Code generation helpers are listed in [`api/helpers.h`](api/helpers.h) and code generation functions are listed in `api/emit_<INST SET>.h` headers, which are generated at build-time).
+The plugin API is event-driven. Plugins should use an initialisation function with `__attribute__((constructor))` to register themselves using `mambo_register_plugin()`. Once a plugin is registered, it can install callbacks for various events using the `mambo_register_*_cb()` functions. Callback-related functions are listed in [`api/plugin_support.h`](api/plugin_support.h). Code generation helpers are listed in [`api/helpers.h`](api/helpers.h) and code generation functions are listed in `api/emit_<INST SET>.h` headers, which are generated at build-time).
 
 Sample plugins are available in the [`plugins/`](plugins) directory.
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ Tip: When an application running under MAMBO exits, the string `We're done; exit
 Plugin API
 ----------
 
-The plugin API is event-driven. Plugins should use a init function with `__attribute__((constructor))` to register themselves using `mambo_register_plugin()`. Once a plugin is registered, it can install callbacks for various events using the `mambo_register_*_cb()` functions. Callback-related functions are listed in `api/plugin_support.h`. Code generation functions are listed in `api/emit_<INST SET>.h` and code generation helpers are listed in `api/helpers.h`. You can also inspect the sample plugin in the `plugins/` directory.
+The plugin API is event-driven. Plugins should use a init function with `__attribute__((constructor))` to register themselves using `mambo_register_plugin()`. Once a plugin is registered, it can install callbacks for various events using the `mambo_register_*_cb()` functions. Callback-related functions are listed in [`api/plugin_support.h`](api/plugin_support.h). Code generation helpers are listed in [`api/helpers.h`](api/helpers.h) and code generation functions are listed in `api/emit_<INST SET>.h` headers, which are generated at build-time).
 
-To build MAMBO with plugin support, the source code or object file(s) of the plugin you're trying to build must be added to the `PLUGINS=` line in the `makefile`, or provided as an argument/envvar. Note that multiple plugins can be enabled at the same time (and will work correctly if properly designed). For performance reasons, it is recommended to remove unused plugins from the `PLUGINS=` list.
+Sample plugins are available in the [`plugins/`](plugins) directory.
+
+To build MAMBO with plugin support, the source code or object file(s) of the plugin you're trying to build must be added to the `PLUGINS=` line in the `makefile`, or provided as an argument/envvar. Note that multiple plugins can be enabled at the same time (and will work correctly if properly designed). For performance reasons, it is recommended to remove unused plugins from the `PLUGINS=` list. Additional arguments that are required to build the plugins can be provided through `PLUGIN_ARGS`.
 
 
 Known issues


### PR DESCRIPTION
~This PR is one commit ahead of #50, so I'll keep it as a draft until that PR is merged.~

In this PR, the "Plugin API" section of the readme is updated, in order to explain the usage of PLUGIN_ARGS (introduced in #36). By the way, references to local resources are replaced with links.
