### PR TITLE
Riscv BRANCH_FSPACE patch

### DIFF
--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -27,7 +27,7 @@
 #include "scanner_common.h"
 
 #define MIN_FSPACE 56
-#define BRANCH_FSPACE 96
+#define BRANCH_FSPACE 112
 
 //#define DEBUG
 #ifdef DEBUG


### PR DESCRIPTION
BRANCH_FSPACE is incremented to 112 from 96 in order to deal with a BNE which can overflow the code cache