### PR TITLE
makefile: allow overriding GIT_VERSION

### DIFF
--- a/makefile
+++ b/makefile
@@ -21,8 +21,9 @@ OPTS+=-DDBM_INLINE_HASH
 OPTS+=-DDBM_TRACES #-DTB_AS_TRACE_HEAD #-DBLXI_AS_TRACE_HEAD
 #OPTS+=-DCC_HUGETLB -DMETADATA_HUGETLB
 
+GIT_VERSION?=$(shell git describe --abbrev=8 --dirty --always || echo '\<nogit\>')
 CFLAGS+=-D_GNU_SOURCE -g -std=gnu99 -O2 -Wunused-variable
-CFLAGS+=-DGIT_VERSION=\"$(shell git describe --abbrev=8 --dirty --always || echo '\<nogit\>')\"
+CFLAGS+=-DGIT_VERSION=\"$(GIT_VERSION)\"
 
 LDFLAGS+=-static -ldl
 LIBS=-lelf -lpthread -lz


### PR DESCRIPTION
Currently, `git describe` produces `651c7665-dirty` because the tags in this repo are unannotated tags. This PR adds option `--tags` in order to take those into account and produce `2-21-g651c7665-dirty` instead.