### PR TITLE
accept some command line options (--help, --version) 

### DIFF
--- a/dbm.c
+++ b/dbm.c
@@ -34,6 +34,7 @@
 
 #include "dbm.h"
 #include "common.h"
+#include "info.h"
 #include "scanner_common.h"
 
 #include "elf/elf_loader.h"
@@ -601,13 +602,24 @@ void notify_vm_op(vm_op_t op, uintptr_t addr, size_t size, int prot, int flags, 
 #endif
 }
 
-void main(int argc, char **argv, char **envp) {
-  Elf *elf = NULL;
-  
+void parse_args(int argc, char **argv, char **envp) {
   if (argc < 2) {
-    printf("Syntax: dbm elf_file arguments\n");
+    usage(argv[0]);
     exit(EXIT_FAILURE);
+  } else if (!strcmp(argv[1], "--help")) {
+    usage(argv[0]);
+    exit(EXIT_SUCCESS);
+  } else if (!strcmp(argv[1], "--version")) {
+    version(true);
+    exit(EXIT_SUCCESS);
   }
+  return;
+}
+
+void main(int argc, char **argv, char **envp) {
+  parse_args(argc, argv, envp);
+
+  Elf *elf = NULL;
 
   global_data.argc = argc;
   global_data.argv = argv;

--- a/info.c
+++ b/info.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "dbm.h"
+#include "info.h"
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+void author() {
+    printf("\
+Written by Cosmin Gorgovan, with contributions from Guillermo Callaghan\n\
+and others (github.com/beehive-lab/mambo/graphs/contributors).\n\
+\n\
+Licensed under the Apache License, Version 2.0. MAMBO is distributed on an\n\
+\"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express\n\
+or implied.\n\
+");
+}
+
+void version(bool full) {
+  printf("MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (%s)\n", DBM_VERSION);
+  if (full) {
+#if defined(__GNUC__)
+    const char *compiler="GNU GCC";
+    const char *compiler_version=xstr(__GNUC__)"."xstr(__GNUC_MINOR__)"."xstr(__GNUC_PATCHLEVEL__);
+#else
+    const char *compiler="Unknown";
+    const char *compiler_version="";
+#endif
+    printf(" Compiled with %s %s\n", compiler, compiler_version);
+
+    author();
+  }
+  printf("\n");
+  return;
+}
+
+void usage(char *argv0) {
+  version(false);
+  printf("Usage: %s <elf_file> [<arguments>]\n", argv0);
+
+#ifdef PLUGINS_NEW
+  printf("\nPlugins:\n\n");
+  mambo_plugin *plugins = global_data.plugins;
+  for (int i = 0; i < global_data.free_plugin; i++) {
+    printf("  [%i] 0x%" PRIxPTR "\n", i, plugins[i].cbs);
+  }
+
+  watched_functions_t *wf = &global_data.watched_functions;
+
+  if (wf->func_count) {
+    printf("\nWatched func: %i\n\n", wf->func_count);
+    for (int i = 0; i < wf->func_count; i++) {
+      watched_func_t *func = &wf->funcs[i];
+      printf("  %s [%i]\n", func->name, func->plugin_id);
+    }
+  }
+  if (wf->funcp_count) {
+    printf("\nWatched funcp: %i\n\n", wf->funcp_count);
+    for (int i = 0; i < wf->funcp_count; i++) {
+      watched_funcp_t *funcp = &wf->funcps[i];
+      printf("  0x%" PRIxPTR " %s [%i]\n", funcp->addr, funcp->func->name, funcp->func->plugin_id);
+    }
+  }
+#endif
+
+  printf("\n");
+  return;
+}

--- a/info.h
+++ b/info.h
@@ -1,0 +1,11 @@
+#ifndef DBM_VERSION
+#ifdef VERSION
+  #define DBM_VERSION VERSION
+#else
+  #define DBM_VERSION "untracked"
+#endif
+#endif
+
+void author(void);
+void version(bool full);
+void usage(char *argv0);

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ LDFLAGS+=-static -ldl
 LIBS=-lelf -lpthread -lz
 HEADERS=*.h makefile
 INCLUDES=-I/usr/include/libelf -I.
-SOURCES= common.c dbm.c traces.c syscalls.c dispatcher.c signals.c util.S
+SOURCES= common.c info.c dbm.c traces.c syscalls.c dispatcher.c signals.c util.S
 SOURCES+=api/helpers.c api/plugin_support.c api/branch_decoder_support.c api/load_store.c api/internal.c api/hash_table.c
 SOURCES+=elf/elf_loader.o elf/symbol_parser.o
 

--- a/test/test_info.sh
+++ b/test/test_info.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+cd $(dirname "$0")/..
+
+. ./test/utils.sh
+
+run_cmd() {
+  gstart "> $1"
+  shift
+  $@
+  echo "Exit code: $?"
+  gend
+}
+
+run_cmd "Build MAMBO (without plugins or CFLAGS)" \
+  make clean all
+
+run_cmd "Run ./dbm (without plugins or CFLAGS)" \
+  ./dbm
+
+run_cmd "Run ./dbm --help (without plugins or CFLAGS)" \
+  ./dbm --help
+
+run_cmd "Run ./dbm --version (without plugins or CFLAGS)" \
+  ./dbm --version
+
+gstart "> Build MAMBO (with plugins and CFLAGS)"
+PLUGINS="plugins/branch_count.c plugins/symbol_example.c" \
+CFLAGS='-DDBM_VERSION=\"v0\"' \
+make clean all
+echo "Exit code: $?"
+gend
+
+run_cmd "Run ./dbm (with plugins and CFLAGS)" \
+  ./dbm
+
+run_cmd "Run ./dbm --help (with plugins and CFLAGS)" \
+  ./dbm --help
+
+run_cmd "Run ./dbm --version (with plugins and CFLAGS)" \
+  ./dbm --version

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+ANSI_BLACK="\e[30m"
+ANSI_RED="\e[31m"
+ANSI_GREEN="\e[32m"
+ANSI_YELLOW="\e[33m"
+ANSI_BLUE="\e[34m"
+ANSI_MAGENTA="\e[35m"
+ANSI_CYAN="\e[36m"
+ANSI_DARK_GRAY="\e[90m"
+ANSI_LIGHT_GRAY="\e[37m"
+ANSI_LIGHT_RED="\e[91m"
+ANSI_LIGHT_GREEN="\e[92m"
+ANSI_LIGHT_YELLOW="\e[93m"
+ANSI_LIGHT_BLUE="\e[94m"
+ANSI_LIGHT_MAGENTA="\e[95m"
+ANSI_LIGHT_CYAN="\e[96m"
+ANSI_WHITE="\e[97m"
+ANSI_NOCOLOR="\e[0m"
+
+print_start() {
+  COL="$ANSI_YELLOW"
+  if [ "x$2" != "x" ]; then
+    COL="$2"
+  fi
+  printf "${COL}${1}$ANSI_NOCOLOR\n"
+}
+
+gstart () {
+  print_start "$@"
+}
+gend () {
+  :
+}
+
+if [ -n "$CI" ]; then
+  echo "INFO: set 'gstart' and 'gend' for CI"
+  gstart () {
+    printf '::group::'
+    print_start "$@"
+    SECONDS=0
+  }
+
+  gend () {
+    duration=$SECONDS
+    echo '::endgroup::'
+    printf "${ANSI_GRAY}took $(($duration / 60)) min $(($duration % 60)) sec.${ANSI_NOCOLOR}\n"
+  }
+fi


### PR DESCRIPTION
This PR adds support for CLI options `--help` and `--version`. Moreover, a shell script named `test/test_info.sh` is added for testing purposes.

The version string is set through DBM_VERSION, which defaults to VERSION, otherwise to `untracked`.

If plugins are enabled, the full help prints the list of plugins. Furthermore, if functions are watched, those are listed, along with the id of plugin which they belong.

See example output without plugins or CFLAGS:

```
> Run ./dbm (without plugins or CFLAGS)
MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (<nogit>)

Usage: ./dbm <elf_file> [<arguments>]

Exit code: 1
```

```
> Run ./dbm --help (without plugins or CFLAGS)
MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (<nogit>)

Usage: ./dbm <elf_file> [<arguments>]

Exit code: 0
```

```
> Run ./dbm --version (without plugins or CFLAGS)
MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (<nogit>)
 Compiled with GNU GCC 7.5.0
Written by Cosmin Gorgovan, with contributions from Guillermo Callaghan
and others (github.com/beehive-lab/mambo/graphs/contributors).

Licensed under the Apache License, Version 2.0. MAMBO is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
or implied.

Exit code: 0
```

And with two plugins enabled, as well as overriding DBM_VERSION:

```
> Run ./dbm (with plugins and CFLAGS)
MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (v0)

Usage: ./dbm <elf_file> [<arguments>]

Plugins:

  [0] 0x70000c3970
  [1] 0x70000c39f0

Watched func: 1

  malloc [1]

Exit code: 1
```

```
> Run ./dbm --help (with plugins and CFLAGS)
MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (v0)

Usage: ./dbm <elf_file> [<arguments>]

Plugins:

  [0] 0x70000c3970
  [1] 0x70000c39f0

Watched func: 1

  malloc [1]

Exit code: 0
```

```
> Run ./dbm --version (with plugins and CFLAGS)
MAMBO: A Low-Overhead Dynamic Binary Modification Tool for ARM (v0)
 Compiled with GNU GCC 7.5.0
Written by Cosmin Gorgovan, with contributions from Guillermo Callaghan
and others (github.com/beehive-lab/mambo/graphs/contributors).

Licensed under the Apache License, Version 2.0. MAMBO is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
or implied.

Exit code: 0
```

Ref: #37