### PR TITLE
Delete unused variables

### DIFF
--- a/common.c
+++ b/common.c
@@ -86,7 +86,6 @@ uintptr_t hash_lookup(hash_table *table, uintptr_t key) {
 
 bool hash_add(hash_table *table, uintptr_t key, uintptr_t value) {
   int index = GET_INDEX(key);
-  int prev_index;
   bool done = false;
   
   do {
@@ -98,7 +97,6 @@ bool hash_add(hash_table *table, uintptr_t key, uintptr_t value) {
       table->entries[index].value = value;
       done = true;
     } else {
-      prev_index = index;
       index++;
       if (index >= table->size -1) {
         fprintf(stderr, "Hash table index overflow\n");

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -47,10 +47,6 @@ void dispatcher(uintptr_t target, uint32_t source_index, uintptr_t *next_addr, d
   bool        cached;
   branch_type source_branch_type;
 
-#ifdef __aarch64__
-  uint32_t *branch_addr;
-#endif // __arch64__
-
 /* It's essential to copy exit_branch_type before calling lookup_or_scan
      because when scanning a stub basic block the source block and its
      meta-information get overwritten */

--- a/traces.c
+++ b/traces.c
@@ -118,12 +118,6 @@ uint32_t scan_trace(dbm_thread *thread_data, void *address, cc_type type, int *s
   fragment_len = scan_a64(thread_data, (uint32_t *)address, trace_id, type, (uint32_t*)write_p);
 #endif
 
-#ifdef __arm__
-  inst_set inst_type = thumb ? THUMB_INST : ARM_INST;
-#elif __aarch64__
-  inst_set inst_type = A64_INST;
-#endif
-
   __clear_cache(write_p, write_p + fragment_len);
 
   thread_data->trace_fragment_count++;


### PR DESCRIPTION
This PR deletes 3 unused variables:
1. `prev_index` in `hash_add` (`common.c`)
2. `branch_addr` in the `dispatcher` (`dispatcher.c`)
3.  `inst_type` in `scan_trace` (`traces.c`)