### PR TITLE
test/load_store.S: fix pseudo-instructions on AArch32

### DIFF
--- a/test/load_store.S
+++ b/test/load_store.S
@@ -365,8 +365,8 @@ test_thumb32:
   VPOP  {S4-S8}
   VPUSH {D4-D15}
   VPOP  {D4-D15}
-  VPUSH {S0-S31}
-  VPOP  {S0-S31}
+  vstmdb sp!, {s0-s31} // VPUSH {s0-s31}
+  vldm   sp!, {s0-s31} // VPOP  {S0-S31}
   VPUSH {D16-D31}
   VPOP  {D16-D31}
 
@@ -1178,10 +1178,10 @@ test_a32:
   // VPUSH, VPOP
   VPUSH {S0}
   VPUSH {D0}
-  VPUSH {S0-S31}
+  vstmdb sp!, {s0-s31} // VPUSH {S0-S31}
   VPUSH {D0-D15}
   VPOP {D0-D15}
-  VPOP {S0-S31}
+  vldm   sp!, {s0-s31} // VPOP  {S0-S31}
   VPOP {D0}
   VPOP {S0}
 


### PR DESCRIPTION
> https://github.com/GuillermoCallaghan/mambo/pull/8#discussion_r776340961
> The error is coming from the assembler, which is no understanding `vpush` and `vpop`. It seem that at some point the understanding of the pseudo-instructions (at least `vpush` and `vpop`) was changed. The pseudo-instructions were understood fine on older versions of `gcc` ([Bug#929155: An Odd Error Message on GNU assembler](https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1680623.html)).

> https://github.com/GuillermoCallaghan/mambo/pull/8#issuecomment-1002617934
> In order to make the `load_store` test work for `AArch32` we need to change the pseudo-instructions (`vpush` and `vpop`) for the actual instructions they alias as they are understood by the assembler.
>
> (...)
>
> Once compiled, if the binary is disassembled, they are shown correctly as the pseudo-instructions (`vpush` and `vpop`):
