### PR TITLE
[DEBUG] Fix compiling warnings

### DIFF
--- a/api/helpers.c
+++ b/api/helpers.c
@@ -317,7 +317,6 @@ int __emit_branch_cond(inst_set inst_type, void *write, uintptr_t target, mambo_
   if (cond == AL) {
     if (diff < -134217728 || diff > 134217724) return -1;
     a64_branch_helper(write, target, link);
-    //a64_b_helper(write, target);
   } else {
     if (diff < -1048576 || diff > 1048572) return -1;
     a64_b_cond_helper(write, target, cond);

--- a/arch/aarch32/dispatcher_aarch32.c
+++ b/arch/aarch32/dispatcher_aarch32.c
@@ -82,7 +82,6 @@ void dispatcher_aarch32(dbm_thread *thread_data, uint32_t source_index, branch_t
         break;
       }
     #endif
-      //thread_data->code_cache_meta[source_index].count++;
       branch_addr = thread_data->code_cache_meta[source_index].exit_branch_addr;
     #ifdef FAST_BT
       uint32_t *branch_table = (uint32_t *)(((uint32_t)branch_addr + 20 + 2) & 0xFFFFFFFC);

--- a/arch/aarch32/scanner_a32.c
+++ b/arch/aarch32/scanner_a32.c
@@ -1491,7 +1491,6 @@ size_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block
       }
 
       case ARM_BFC: {
-      //case ARM_BFI: {
         uint32_t rd, lsb, msb;
         arm_bfc_decode_fields(read_address, &rd, &lsb, &msb);
         assert(rd != pc);

--- a/arch/aarch32/scanner_a32.c
+++ b/arch/aarch32/scanner_a32.c
@@ -753,7 +753,7 @@ size_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block
         if ((*read_address >> 28) != AL) {
           debug("w: %p, r: %p, bb: %d\n", write_p, read_address, basic_block);
           target = lookup_or_stub(thread_data, (uint32_t)read_address + 4);
-          debug("stub: %p\n", target);
+          debug("stub: 0x%x\n", target);
           arm_cc_branch(thread_data,write_p, target,
                         arm_inverse_cond_code[(*read_address >> 28)]);
           write_p++;

--- a/arch/aarch32/scanner_t32.c
+++ b/arch/aarch32/scanner_t32.c
@@ -2510,12 +2510,9 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
 #ifdef DBM_LINK_COND_IMM
         }
 #endif
-        
         stop = true;
-        
-        //while(1);
         break;
-        
+
       case THUMB_DSB32:
       case THUMB_DMB32:
       case THUMB_ISB32:
@@ -2898,7 +2895,6 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
         thumb_mrc32_decode_fields(read_address, &opc1, &crn, &rt, &coproc, &opc2, &crm);
 
         if (coproc == 15 && opc1 == 0 && crn == 13 && crm == 0 && opc2 == 3) {
-          //fprintf(stderr, "Read TPIDRURO into R%d\n", rt);
           assert(rt != pc);
 
           modify_in_it_pre(5);
@@ -3117,7 +3113,6 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
       if(!it_cond_handled) {
         fprintf(stderr, "Didn't handle instruction-after IT at %p, inst: %d\n", read_address, inst);
         while(1);
-        //exit(EXIT_FAILURE);
       }
       do_it_iter(&it_state);
     }

--- a/arch/aarch64/scanner_a64.c
+++ b/arch/aarch64/scanner_a64.c
@@ -36,35 +36,13 @@
 #define NOP_INSTRUCTION 0xD503201F
 #define MIN_FSPACE      60
 
-//#define DEBUG
 #ifdef DEBUG
   #define debug(...) fprintf(stderr, __VA_ARGS__)
 #else
   #define debug(...)
 #endif
 
-/*
- * Macros for Pushing and Poping pair or single registers.
- * ====== === ======= === ====== ==== == ====== =========
- *
- *                     PUSH-POP Pair of registers
- *
- * The "L" field defines if the instruction is a Load (L = 1) or a
- * Store (L = 0).
- * The field "type" controls the addressing mode.
- *      C4.3.15 Load/store register pair (post-indexed, page 205.
- *      C4.3.16 Load/store register pair (pre-indexed), page 206.
- *
- * A64_LDP_STP_encode (address, opc, V, type, L, imm7, Rt2, Rn, Rt)
- * imm7:
- * For the 64-bit post-index and 64-bit pre-index variant: is the signed
- * immediate byte offset, a multiple of 8 in the range -512 to 504, encoded
- * in the "imm7" field as <imm>/8. Page 668.
-*/
-
 #define a64_copy() *(write_p++) = *read_address;
-
-#define a64_brk() *(write_p++) = 0xD4200000;
 
 void a64_branch_helper(uint32_t *write_p, uint64_t target, bool link) {
   int64_t difference = target - (uint64_t)write_p;
@@ -768,7 +746,6 @@ size_t scan_a64(dbm_thread *thread_data, uint32_t *read_address,
         a64_branch_jump(thread_data, &write_p, basic_block, target,
                         REPLACE_TARGET | INSERT_BRANCH);
         stop = true;
-        //while(1);
         break;
 
       case A64_BR:

--- a/common.c
+++ b/common.c
@@ -34,7 +34,6 @@
 #include "common.h"
 #include "scanner_public.h"
 
-//#undef DEBUG
 #ifdef DEBUG
   #define debug(...) fprintf(stderr, __VA_ARGS__)
 #else

--- a/dbm.c
+++ b/dbm.c
@@ -151,7 +151,7 @@ uintptr_t stub_bb(dbm_thread *thread_data, uintptr_t target) {
   basic_block = allocate_bb(thread_data);
   block_address = (uintptr_t)&thread_data->code_cache->blocks[basic_block];
   
-  debug("Stub BB: 0x%x\n", block_address + thumb);
+  debug("Stub BB: 0x%" PRIxPTR "\n", block_address + thumb);
   
   thread_data->code_cache_meta[basic_block].exit_branch_type = stub;
   if (!hash_add(&thread_data->entry_address, target, block_address + thumb)) {
@@ -176,7 +176,7 @@ uintptr_t stub_bb(dbm_thread *thread_data, uintptr_t target) {
 uintptr_t lookup_or_stub(dbm_thread *thread_data, uintptr_t target) {
   uintptr_t block_address;
   
-  debug("Stub(0x%x)\n", target);
+  debug("Stub (0x%" PRIxPTR ")\n", target);
   debug("Thread_data: %p\n", thread_data);
   
   block_address = cc_lookup(thread_data, target);
@@ -429,7 +429,7 @@ void init_thread(dbm_thread *thread_data) {
 
   thread_data->status = THREAD_RUNNING;
                         
-  debug("Syscall wrapper addr: 0x%x\n", thread_data->syscall_wrapper_addr);
+  debug("Syscall wrapper addr: 0x%" PRIxPTR "\n", thread_data->syscall_wrapper_addr);
 }
 
 void free_all_other_threads(dbm_thread *thread_data) {
@@ -534,7 +534,7 @@ int addr_to_fragment_id(dbm_thread * const thread_data, const uintptr_t addr) {
 void record_cc_link(dbm_thread *thread_data, uintptr_t linked_from, uintptr_t linked_to_addr) {
   int linked_to = addr_to_bb_id(thread_data, linked_to_addr);
 
-  debug("Linked 0x%x (%d) from 0x%x\n", linked_to_addr, linked_to, linked_from);
+  debug("Linked 0x%" PRIxPTR " (%d) from 0x%" PRIxPTR "\n", linked_to_addr, linked_to, linked_from);
 
   if (linked_to < 0) return;
 
@@ -631,7 +631,7 @@ void main(int argc, char **argv, char **envp) {
   struct elf_loader_auxv auxv;
   uintptr_t entry_address;
   load_elf(argv[1], &elf, &auxv, &entry_address, false);
-  debug("entry address: 0x%x\n", entry_address);
+  debug("entry address: 0x%" PRIxPTR "\n", entry_address);
 
   // Set up brk emulation
   ret = pthread_mutex_init(&global_data.brk_mutex, NULL);
@@ -653,7 +653,7 @@ void main(int argc, char **argv, char **envp) {
   register_thread(thread_data, false);
 
   uintptr_t block_address = scan(thread_data, (uint16_t *)entry_address, ALLOCATE_BB);
-  debug("Address of first basic block is: 0x%x\n", block_address);
+  debug("Address of first basic block is: 0x%" PRIxPTR "\n", block_address);
 
   #define ARGDIFF 2
   elf_run(block_address, argv[1], argc-ARGDIFF, &argv[ARGDIFF], envp, &auxv);

--- a/dbm.c
+++ b/dbm.c
@@ -475,6 +475,13 @@ bool is_bb(dbm_thread * const thread_data, const uintptr_t addr) {
   return (addr >= cc_start) && (addr < bbc_end);
 }
 
+bool is_trace(dbm_thread * const thread_data, const uintptr_t addr) {
+  const uintptr_t bbc_end = (uintptr_t)thread_data->code_cache->traces;
+  const uintptr_t cc_end = bbc_end + TRACE_CACHE_SIZE;
+
+  return (addr >= bbc_end) && (addr < cc_end);
+}
+
 int addr_to_bb_id(dbm_thread * const thread_data, const uintptr_t addr) {
   const uintptr_t cc_start = (uintptr_t)thread_data->code_cache->blocks;
   const uintptr_t bbc_end = (uintptr_t)thread_data->code_cache->traces;

--- a/dbm.c
+++ b/dbm.c
@@ -130,18 +130,13 @@ inline uintptr_t lookup_or_scan_with_cached(dbm_thread * const thread_data,
 }
 
 int allocate_bb(dbm_thread *thread_data) {
-  unsigned int basic_block;
-  bool flushed = false;
-
   // Reserve CODE_CACHE_OVERP basic blocks to be able to scan large blocks
   if(thread_data->free_block >= (CODE_CACHE_SIZE - CODE_CACHE_OVERP)) {
     fprintf(stderr, "code cache full, flushing it\n");
     flush_code_cache(thread_data);
-    flushed = true;
   }
-  
-  basic_block = thread_data->free_block++;
-  return basic_block;
+
+  return thread_data->free_block++;
 }
 
 /* Stub BBs only contain a call to the dispatcher
@@ -211,7 +206,6 @@ uintptr_t scan(dbm_thread *thread_data, uint16_t *address, int basic_block) {
   block_address = (uintptr_t)&thread_data->code_cache->blocks[basic_block];
   thread_data->code_cache_meta[basic_block].source_addr = address;
   thread_data->code_cache_meta[basic_block].tpc = block_address;
-  //fprintf(stderr, "scan(%p): 0x%x (bb %d)\n", address, block_address, basic_block);
 
   // Add entry into the code cache hash table
   // It must be added before scan_ is called, otherwise a call for scan

--- a/dbm.c
+++ b/dbm.c
@@ -468,27 +468,27 @@ void reset_process(dbm_thread *thread_data) {
   mambo_deliver_callbacks(PRE_THREAD_C, thread_data);
 }
 
-bool is_bb(dbm_thread *thread_data, uintptr_t addr) {
-  uintptr_t min = (uintptr_t)thread_data->code_cache->blocks;
-  uintptr_t max = (uintptr_t)thread_data->code_cache->traces;
+bool is_bb(dbm_thread * const thread_data, const uintptr_t addr) {
+  const uintptr_t cc_start = (uintptr_t)thread_data->code_cache->blocks;
+  const uintptr_t bbc_end = (uintptr_t)thread_data->code_cache->traces;
 
-  return addr >= min && addr < max;
+  return (addr >= cc_start) && (addr < bbc_end);
 }
 
-int addr_to_bb_id(dbm_thread *thread_data, uintptr_t addr) {
-  uintptr_t min = (uintptr_t)thread_data->code_cache->blocks;
-  uintptr_t max = (uintptr_t)thread_data->code_cache->traces;
+int addr_to_bb_id(dbm_thread * const thread_data, const uintptr_t addr) {
+  const uintptr_t cc_start = (uintptr_t)thread_data->code_cache->blocks;
+  const uintptr_t bbc_end = (uintptr_t)thread_data->code_cache->traces;
 
-  if (addr < min || addr > max) {
+  if (addr < cc_start || addr > bbc_end) {
     return -1;
   }
 
-  return (addr - (uintptr_t)thread_data->code_cache->blocks) / sizeof(dbm_block);
+  return (addr - cc_start) / sizeof(dbm_block);
 }
 
-int addr_to_fragment_id(dbm_thread *thread_data, uintptr_t addr) {
-  uintptr_t start = (uintptr_t )thread_data->code_cache->blocks;
-  assert(addr >= start && addr < (start + MAX_BRANCH_RANGE));
+int addr_to_fragment_id(dbm_thread * const thread_data, const uintptr_t addr) {
+  const uintptr_t cc_start = (uintptr_t)thread_data->code_cache->blocks;
+  assert(addr >= cc_start && addr < (cc_start + MAX_BRANCH_RANGE));
 
   int id = addr_to_bb_id(thread_data, addr);
   if (id >= 0) {

--- a/dbm.h
+++ b/dbm.h
@@ -339,6 +339,7 @@ int addr_to_bb_id(dbm_thread * const thread_data, const uintptr_t addr);
 int addr_to_fragment_id(dbm_thread * const thread_data, const uintptr_t addr);
 void record_cc_link(dbm_thread *thread_data, uintptr_t linked_from, uintptr_t linked_to_addr);
 bool is_bb(dbm_thread * const thread_data, const uintptr_t addr);
+bool is_trace(dbm_thread * const thread_data, const uintptr_t addr);
 
 void install_system_sig_handlers();
 

--- a/dbm.h
+++ b/dbm.h
@@ -317,7 +317,10 @@ void init_thread(dbm_thread *thread_data);
 void reset_process(dbm_thread *thread_data);
 
 uintptr_t cc_lookup(dbm_thread *thread_data, uintptr_t target);
-uintptr_t lookup_or_scan(dbm_thread *thread_data, uintptr_t target, bool *cached);
+uintptr_t lookup_or_scan(dbm_thread * const thread_data, uintptr_t target);
+uintptr_t lookup_or_scan_with_cached(dbm_thread * const thread_data,
+                                     const uintptr_t target,
+                                     bool * const cached);
 uintptr_t lookup_or_stub(dbm_thread *thread_data, uintptr_t target);
 uintptr_t scan(dbm_thread *thread_data, uint16_t *address, int basic_block);
 uint32_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block, cc_type type, uint32_t *write_p);

--- a/dbm.h
+++ b/dbm.h
@@ -335,10 +335,11 @@ void sigret_dispatcher_call(dbm_thread *thread_data, ucontext_t *cont, uintptr_t
 void thumb_encode_stub_bb(dbm_thread *thread_data, int basic_block, uint32_t target);
 void arm_encode_stub_bb(dbm_thread *thread_data, int basic_block, uint32_t target);
 
-int addr_to_bb_id(dbm_thread *thread_data, uintptr_t addr);
-int addr_to_fragment_id(dbm_thread *thread_data, uintptr_t addr);
+int addr_to_bb_id(dbm_thread * const thread_data, const uintptr_t addr);
+int addr_to_fragment_id(dbm_thread * const thread_data, const uintptr_t addr);
 void record_cc_link(dbm_thread *thread_data, uintptr_t linked_from, uintptr_t linked_to_addr);
-bool is_bb(dbm_thread *thread_data, uintptr_t addr);
+bool is_bb(dbm_thread * const thread_data, const uintptr_t addr);
+
 void install_system_sig_handlers();
 
 #define MAP_INTERP (0x40000000)

--- a/dbm.h
+++ b/dbm.h
@@ -27,7 +27,7 @@
 #include <stdint.h>
 #include <sys/auxv.h>
 #include <libelf.h>
-
+#include <inttypes.h>
 #ifdef __arm__
 #include "pie/pie-arm-decoder.h"
 #include "pie/pie-thumb-decoder.h"

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -20,15 +20,17 @@
 */
 
 #include <stdio.h>
-#include <limits.h>
 
 #include "dbm.h"
 #include "scanner_common.h"
 #ifdef __arm__
-#include "pie/pie-thumb-encoder.h"
-#include "pie/pie-arm-encoder.h"
+void dispatcher_aarch32(dbm_thread *thread_data, uint32_t source_index,
+                        branch_type exit_type, uintptr_t target,
+                        uintptr_t block_address);
 #elif __aarch64__
-#include "pie/pie-a64-encoder.h"
+void dispatcher_aarch64(dbm_thread *thread_data, uint32_t source_index,
+                        branch_type exit_type, uintptr_t target,
+                        uintptr_t block_address);
 #endif
 
 #ifdef DEBUG
@@ -37,21 +39,14 @@
   #define debug(...)
 #endif
 
-void dispatcher_aarch32(dbm_thread *thread_data, uint32_t source_index, branch_type exit_type,
-                        uintptr_t target, uintptr_t block_address);
-void dispatcher_aarch64(dbm_thread *thread_data, uint32_t source_index, branch_type exit_type,
-                        uintptr_t target, uintptr_t block_address);
-
-void dispatcher(uintptr_t target, uint32_t source_index, uintptr_t *next_addr, dbm_thread *thread_data) {
-  uintptr_t   block_address;
-  bool        cached;
-  branch_type source_branch_type;
-
+void dispatcher(const uintptr_t target, const uint32_t source_index,
+                uintptr_t * const next_addr, dbm_thread * const thread_data) {
 /* It's essential to copy exit_branch_type before calling lookup_or_scan
      because when scanning a stub basic block the source block and its
      meta-information get overwritten */
   debug("Source block index: %d\n", source_index);
-  source_branch_type = thread_data->code_cache_meta[source_index].exit_branch_type;
+  branch_type source_branch_type =
+                    thread_data->code_cache_meta[source_index].exit_branch_type;
 
 #ifdef DBM_TRACES
   // Handle trace exits separately
@@ -63,16 +58,22 @@ void dispatcher(uintptr_t target, uint32_t source_index, uintptr_t *next_addr, d
   }
 #endif
 
-  debug("Reached the dispatcher, target: 0x%x, ret: %p, src: %d thr: %p\n", target, next_addr, source_index, thread_data);
+  debug("Reached the dispatcher, target: 0x%x, ret: %p, src: %d thr: %p\n",
+        target, next_addr, source_index, thread_data);
   thread_data->was_flushed = false;
-  block_address = lookup_or_scan_with_cached(thread_data, target, &cached);
-  if (cached) {
-    debug("Found block from %d for 0x%x in cache at 0x%x\n", source_index, target, block_address);
-  } else {
-    debug("Scanned at 0x%x for 0x%x\n", block_address, target);
-  }
 
-  *next_addr = block_address;
+#ifdef DEBUG
+  bool cached;
+  *next_addr = lookup_or_scan_with_cached(thread_data, target, &cached);
+  if (cached) {
+    debug("Found block from %d for 0x%x in cache at 0x%x\n",
+          source_index, target, *next_addr);
+  } else {
+    debug("Scanned at 0x%x for 0x%x\n", *next_addr, target);
+  }
+#else
+   *next_addr = lookup_or_scan(thread_data, target);
+#endif
 
   // Bypass any linking
   if (source_index == 0 || thread_data->was_flushed) {
@@ -80,9 +81,11 @@ void dispatcher(uintptr_t target, uint32_t source_index, uintptr_t *next_addr, d
   }
 
 #ifdef __arm__
-  dispatcher_aarch32(thread_data, source_index, source_branch_type, target, block_address);
+  dispatcher_aarch32(thread_data, source_index, source_branch_type, target,
+                     *next_addr);
 #endif
 #ifdef __aarch64__
-  dispatcher_aarch64(thread_data, source_index, source_branch_type, target, block_address);
+  dispatcher_aarch64(thread_data, source_index, source_branch_type, target,
+                     *next_addr);
 #endif
 }

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -65,7 +65,7 @@ void dispatcher(uintptr_t target, uint32_t source_index, uintptr_t *next_addr, d
 
   debug("Reached the dispatcher, target: 0x%x, ret: %p, src: %d thr: %p\n", target, next_addr, source_index, thread_data);
   thread_data->was_flushed = false;
-  block_address = lookup_or_scan(thread_data, target, &cached);
+  block_address = lookup_or_scan_with_cached(thread_data, target, &cached);
   if (cached) {
     debug("Found block from %d for 0x%x in cache at 0x%x\n", source_index, target, block_address);
   } else {

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -58,7 +58,7 @@ void dispatcher(const uintptr_t target, const uint32_t source_index,
   }
 #endif
 
-  debug("Reached the dispatcher, target: 0x%x, ret: %p, src: %d thr: %p\n",
+  debug("Reached the dispatcher, target: 0x%" PRIxPTR ", ret: %p, src: %d thr: %p\n",
         target, next_addr, source_index, thread_data);
   thread_data->was_flushed = false;
 
@@ -66,10 +66,10 @@ void dispatcher(const uintptr_t target, const uint32_t source_index,
   bool cached;
   *next_addr = lookup_or_scan_with_cached(thread_data, target, &cached);
   if (cached) {
-    debug("Found block from %d for 0x%x in cache at 0x%x\n",
+    debug("Found block from %d for 0x%" PRIxPTR " in cache at 0x%" PRIxPTR "\n",
           source_index, target, *next_addr);
   } else {
-    debug("Scanned at 0x%x for 0x%x\n", *next_addr, target);
+    debug("Scanned at 0x%" PRIxPTR " for 0x%" PRIxPTR "\n", *next_addr, target);
   }
 #else
    *next_addr = lookup_or_scan(thread_data, target);

--- a/elf/elf_loader.c
+++ b/elf/elf_loader.c
@@ -49,9 +49,11 @@ void load_segment(uintptr_t base_addr, ELF_PHDR *phdr, int fd, Elf32_Half type, 
   int prot = 0;
   uintptr_t aligned_vaddr, aligned_fsize, aligned_msize, page_offset, map_file_end;
 
-  /*if (phdr->p_flags & PF_X) {
+#ifdef ENABLE_EXECUTE
+  if (phdr->p_flags & PF_X) {
     prot |= PROT_EXEC;
-  }*/
+  }
+#endif
 
   if (phdr->p_flags & PF_W) {
     prot |= PROT_WRITE;
@@ -97,11 +99,11 @@ void load_segment(uintptr_t base_addr, ELF_PHDR *phdr, int fd, Elf32_Half type, 
                  prot | ((phdr->p_flags & PF_X) ? PROT_EXEC : 0), MAP_EL_ANON, -1, 0);
   }
 
-  /*
+#ifdef ENABLE_EXECUTE
   if (phdr->p_flags & PF_X) {
     __clear_cache((char *)phdr->p_vaddr, (char *)phdr->p_vaddr + (char *)phdr->p_memsz);
   }
-  */
+#endif
 
   if (!is_interp && (aligned_vaddr + aligned_msize) > global_data.brk) {
     global_data.brk = aligned_vaddr + aligned_msize;

--- a/elf/elf_loader.c
+++ b/elf/elf_loader.c
@@ -36,8 +36,6 @@
   #define AT_MINSIGSTKSZ 51
 #endif
 
-#define DEBUG 1
-#undef DEBUG
 #ifdef DEBUG
   #define debug(...) fprintf(stderr, __VA_ARGS__)
 #else

--- a/plugins/memcheck/naive_stdlib.c
+++ b/plugins/memcheck/naive_stdlib.c
@@ -124,10 +124,8 @@ size_t memcheck_strspn(const char *s, const char *accept) {
   size_t len = 0;
   char *p = (char *)s;
   for (; *p != '\0'; p++) {
-    //printf("%c\n", *p);
     bool match = false;
     for (int i = 0; accept[i] != '\0' && !match; i++) {
-      //printf(" %c\n", accept[i]);
       if (*p == accept[i]) {
         match = true;
         break;

--- a/scanner_common.h
+++ b/scanner_common.h
@@ -31,9 +31,7 @@
   #define APP_SP (r3)
   #define DISP_SP_OFFSET (28)
   #define DISP_RES_WORDS (3)
-#endif
 
-#ifdef __arm__
 void thumb_cc_branch(dbm_thread *thread_data, uint16_t *write_p, uint32_t dest_addr);
 void thumb_b16_cond_helper(uint16_t *write_p, uint32_t dest_addr, mambo_cond cond);
 void thumb_b32_helper(uint16_t *write_p, uint32_t dest_addr);
@@ -88,8 +86,4 @@ void a64_inline_hash_lookup(dbm_thread *thread_data, int basic_block, uint32_t *
                             uint32_t *read_address, enum reg rn, bool link, bool set_meta);
 #endif
 
-extern void inline_hash_lookup();
-extern void end_of_inline_hash_lookup();
-extern void inline_hash_lookup_get_addr();
-extern void inline_hash_lookup_data();
 #endif

--- a/signals.c
+++ b/signals.c
@@ -533,7 +533,7 @@ uintptr_t signal_dispatcher(int i, siginfo_t *info, void *context) {
   }
 
   if (deliver_now) {
-    handler = lookup_or_scan(current_thread, global_data.signal_handlers[i], NULL);
+    handler = lookup_or_scan(current_thread, global_data.signal_handlers[i]);
     return handler;
   }
 
@@ -655,7 +655,7 @@ uintptr_t signal_dispatcher(int i, siginfo_t *info, void *context) {
     }
 
     cont->pc_field = 0;
-    handler = lookup_or_scan(current_thread, handler, NULL);
+    handler = lookup_or_scan(current_thread, handler);
     return handler;
   }
 

--- a/syscalls.c
+++ b/syscalls.c
@@ -187,7 +187,7 @@ ssize_t readlink_handler(char *sys_path, char *sys_buf, ssize_t bufsize) {
 int syscall_handler_pre(uintptr_t syscall_no, uintptr_t *args, uint16_t *next_inst, dbm_thread *thread_data) {
   int do_syscall = 1;
   sys_clone_args *clone_args;
-  debug("syscall pre %d\n", syscall_no);
+  debug("syscall pre %" PRIdPTR "\n", syscall_no);
 
 #ifdef PLUGINS_NEW
   mambo_context ctx;
@@ -485,7 +485,7 @@ int syscall_handler_pre(uintptr_t syscall_no, uintptr_t *args, uint16_t *next_in
 }
 
 void syscall_handler_post(uintptr_t syscall_no, uintptr_t *args, uint16_t *next_inst, dbm_thread *thread_data) {
-  debug("syscall post %d\n", syscall_no);
+  debug("syscall post %" PRIdPTR "\n", syscall_no);
 
   if (global_data.exit_group) {
     thread_abort(thread_data);
@@ -494,7 +494,7 @@ void syscall_handler_post(uintptr_t syscall_no, uintptr_t *args, uint16_t *next_
 
   switch(syscall_no) {
     case __NR_clone:
-      debug("r0 (tid): %d\n", args[0]);
+      debug("r0 (tid): %" PRIdPTR "\n", args[0]);
       if (args[0] == 0) { // the child
         assert(!thread_data->clone_vm);
         /* Without CLONE_VM, the child runs in a separate memory space,

--- a/traces.c
+++ b/traces.c
@@ -252,7 +252,7 @@ void install_trace(dbm_thread *thread_data) {
 
   cc_link = thread_data->code_cache_meta[bb_source].linked_from;
   while(cc_link != NULL) {
-    debug("Link from: 0x%lx, update to: 0x%lx\n", cc_link->data, tpc);
+    debug("Link from: 0x%" PRIxPTR ", update to: 0x%" PRIxPTR "\n", cc_link->data, tpc);
     orig_branch = cc_link->data;
 #ifdef __arm__
     orig_branch &= 0xFFFFFFFE;
@@ -507,7 +507,7 @@ void create_trace(dbm_thread *thread_data, uint32_t bb_source, cc_addr_pair *ret
       return;
     }
 
-    debug("bb: %d, source: %p, ret to: 0x%x\n", bb_source, source_addr, ret_addr->tpc);
+    debug("bb: %d, source: %p, ret to: 0x%" PRIxPTR "\n", bb_source, source_addr, ret_addr->tpc);
     hot_bb_cnt++;
 
     trace_entry = (uintptr_t)thread_data->trace_cache_next;
@@ -520,10 +520,10 @@ void create_trace(dbm_thread *thread_data, uint32_t bb_source, cc_addr_pair *ret
     thread_data->active_trace.entry_addr = trace_entry;
     thread_data->active_trace.free_exit_rec = 0;
 
-    debug("Create trace: %d (%p), source_bb: %d, entry: %lx\n",
+    debug("Create trace: %d (%p), source_bb: %d, entry: %" PRIxPTR "\n",
           thread_data->active_trace.id, thread_data->active_trace.write_p,
           thread_data->active_trace.source_bb, thread_data->active_trace.entry_addr);
-    debug("\n    Trace head: %p at 0x%x\n\n", source_addr, ret_addr->tpc);
+    debug("\n    Trace head: %p at 0x%" PRIxPTR "\n\n", source_addr, ret_addr->tpc);
 
     ret_addr->tpc = adjust_cc_entry(trace_entry);
     fragment_len = scan_trace(thread_data, source_addr, mambo_trace_entry, &trace_id);
@@ -595,7 +595,7 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
   size_t fragment_len;
   thread_data->was_flushed = false;
 
-  debug("Trace dispatcher (target: 0x%x)\n", target);
+  debug("Trace dispatcher (target: 0x%" PRIxPTR ")\n", target);
 
   switch(bb_meta->exit_branch_type) {
 #ifdef __arm__
@@ -724,7 +724,7 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
 
   // Check if the fragment count has reached the max limit
   if (thread_data->trace_fragment_count > MAX_TRACE_FRAGMENTS) {
-    debug("Trace fragment count limit, branch to: 0x%x, written at: %p\n", target, write_p);
+    debug("Trace fragment count limit, branch to: 0x%" PRIxPTR ", written at: %p\n", target, write_p);
     addr = active_trace_lookup_or_scan(thread_data, target);
     early_trace_exit(thread_data, bb_meta, write_p, target, addr);
     *next_addr = addr;
@@ -733,14 +733,14 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
 
   // Check if the target is already a trace
   addr = active_trace_lookup(thread_data, target);
-  debug("Hash lookup for 0x%x: 0x%x\n", target, addr);
+  debug("Hash lookup for 0x%" PRIxPTR ": 0x%" PRIxPTR "\n", target, addr);
   if (addr != UINT_MAX) {
     early_trace_exit(thread_data, bb_meta, write_p, target, addr);
     *next_addr = addr;
     return;
   }
 
-  debug("\n   Trace fragment: 0x%x\n", target);
+  debug("\n   Trace fragment: 0x%" PRIxPTR "\n", target);
   int fragment_id;
 #ifdef __arm__
   fragment_len = scan_trace(thread_data, (uint16_t *)target, mambo_trace, &fragment_id);
@@ -748,7 +748,7 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
 #ifdef __aarch64__
   fragment_len = scan_trace(thread_data, (uint32_t *)target, mambo_trace, &fragment_id);
 #endif
-  debug("len: %d\n\n", fragment_len);
+  debug("len: %" PRIdPTR "\n\n", fragment_len);
 
   thread_data->active_trace.write_p += fragment_len;
   switch(thread_data->code_cache_meta[fragment_id].exit_branch_type) {

--- a/traces.c
+++ b/traces.c
@@ -75,7 +75,7 @@ uintptr_t active_trace_lookup_or_scan(dbm_thread *thread_data, uintptr_t target)
   if (target == spc) {
     return adjust_cc_entry(thread_data->active_trace.entry_addr);
   }
-  return lookup_or_scan(thread_data, target, NULL);
+  return lookup_or_scan(thread_data, target);
 }
 
 uintptr_t active_trace_lookup_or_stub(dbm_thread *thread_data, uintptr_t target) {
@@ -503,7 +503,7 @@ void create_trace(dbm_thread *thread_data, uint32_t bb_source, cc_addr_pair *ret
         || thread_data->trace_id >= (CODE_CACHE_SIZE + TRACE_FRAGMENT_NO - TRACE_FRAGMENT_OVERP)) {
       fprintf(stderr, "trace cache full, flushing the CC\n");
       flush_code_cache(thread_data);
-      ret_addr->tpc = lookup_or_scan(thread_data, (uintptr_t)source_addr, NULL);
+      ret_addr->tpc = lookup_or_scan(thread_data, (uintptr_t)source_addr);
       return;
     }
 
@@ -676,7 +676,7 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
     case tbh:
     case tbb:
     case uncond_reg_arm:
-      *next_addr = lookup_or_scan(thread_data, target, NULL);
+      *next_addr = lookup_or_scan(thread_data, target);
       return;
 
       break;
@@ -705,7 +705,7 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
       bb_meta->branch_cache_status = BRANCH_LINKED;
       break;
     case uncond_branch_reg:
-      *next_addr = lookup_or_scan(thread_data, target, NULL);
+      *next_addr = lookup_or_scan(thread_data, target);
       return;
       break;
 #endif
@@ -719,7 +719,7 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
 
   // If the CC was flushed to generate exits, then abort the active trace
   if (thread_data->was_flushed) {
-    *next_addr = lookup_or_scan(thread_data, target, NULL);
+    *next_addr = lookup_or_scan(thread_data, target);
     return;
   }
 

--- a/traces.c
+++ b/traces.c
@@ -64,10 +64,10 @@ uintptr_t active_trace_lookup(dbm_thread *thread_data, uintptr_t target) {
   if (target == spc) {
     return adjust_cc_entry(thread_data->active_trace.entry_addr);
   }
-  uintptr_t return_tpc = hash_lookup(&thread_data->entry_address, target);
-  if (return_tpc >= (uintptr_t)thread_data->code_cache->traces)
-    return adjust_cc_entry(return_tpc);
-  return UINT_MAX;
+
+  uintptr_t tpc = hash_lookup(&thread_data->entry_address, target);
+
+  return is_trace(thread_data, tpc) ? adjust_cc_entry(tpc) : UINT_MAX;
 }
 
 uintptr_t active_trace_lookup_or_scan(dbm_thread *thread_data, uintptr_t target) {
@@ -264,7 +264,7 @@ void install_trace(dbm_thread *thread_data) {
       arm_adjust_b_bl_target((uintptr_t *)orig_branch, tpc_direct);
     }
 #elif __aarch64__
-    if (orig_branch >= (uintptr_t)thread_data->code_cache->traces) {
+    if (is_trace(thread_data, orig_branch)) {
       patch_trace_branches(thread_data, (uint32_t *)orig_branch, tpc + 4);
     } else {
       a64_b_helper((uint32_t *)orig_branch, tpc + 4);

--- a/traces.c
+++ b/traces.c
@@ -640,7 +640,6 @@ void trace_dispatcher(uintptr_t target, uintptr_t *next_addr, uint32_t source_in
       thumb_bx16(&write_p, pc);
       __clear_cache(write_p-2, write_p+2);
       write_p += 2;
-      //while(1);
     #endif
 
     /* Alternative implementations might be faster on other microarchitectures */


### PR DESCRIPTION
This PR fixes compiler warnings when using `DEBUG`.
This was tested on AArch64 and AArch64, both running `Ubuntu 20.04.3`.
Closes #68 #67 #70