### PR TITLE
Fix functions return type

### DIFF
--- a/api/hash_table.c
+++ b/api/hash_table.c
@@ -77,6 +77,7 @@ int __mambo_ht_resize(mambo_ht_t *ht) {
       assert(ret == 0);
     }
   }
+  return 0;
 }
 
 int mambo_ht_add_nolock(mambo_ht_t *ht, uintptr_t key, uintptr_t value) {
@@ -84,7 +85,8 @@ int mambo_ht_add_nolock(mambo_ht_t *ht, uintptr_t key, uintptr_t value) {
 
   if (ht->entry_count >= ht->resize_threshold) {
     if (ht->allow_resize) {
-      __mambo_ht_resize(ht);
+      const int ret = __mambo_ht_resize(ht);
+      assert(ret == 0);
     } else {
       return -1;
     }

--- a/elf/elf_loader.c
+++ b/elf/elf_loader.c
@@ -110,7 +110,7 @@ void load_segment(uintptr_t base_addr, ELF_PHDR *phdr, int fd, Elf32_Half type, 
   }
 }
 
-int load_elf(char *filename, Elf **ret_elf, struct elf_loader_auxv *auxv, uintptr_t *entry_addr, bool is_interp) {
+void load_elf(char *filename, Elf **ret_elf, struct elf_loader_auxv *auxv, uintptr_t *entry_addr, bool is_interp) {
   int fd;
   FILE *file;
   Elf *elf;

--- a/elf/elf_loader.h
+++ b/elf/elf_loader.h
@@ -46,6 +46,6 @@ struct elf_loader_auxv {
   uintptr_t at_phnum;
 };
 
-int load_elf(char *filename, Elf **ret_elf, struct elf_loader_auxv *auxv, uintptr_t *entry_addr, bool is_interp);
+void load_elf(char *filename, Elf **ret_elf, struct elf_loader_auxv *auxv, uintptr_t *entry_addr, bool is_interp);
 void elf_run(uintptr_t entry_address, char *filename, int argc, char **argv, char **envp, struct elf_loader_auxv *auxv);
 

--- a/elf/symbol_parser.c
+++ b/elf/symbol_parser.c
@@ -167,7 +167,7 @@ void function_watch_unlock_funcps(watched_functions_t *self) {
   assert(ret == 0);
 }
 
-int function_watch_init(watched_functions_t *self) {
+void function_watch_init(watched_functions_t *self) {
   int ret = pthread_mutex_init(&self->funcs_lock, NULL);
   assert(ret == 0);
   ret = pthread_mutex_init(&self->funcps_lock, NULL);
@@ -232,7 +232,7 @@ ret:
   return err;
 }
 
-int function_watch_try_addp(watched_functions_t *self, char *name, void *addr) {
+void function_watch_try_addp(watched_functions_t *self, char *name, void *addr) {
   function_watch_lock_funcs(self);
 
   for (int i = 0; i < self->func_count; i++) {
@@ -267,7 +267,7 @@ int function_watch_delete_addp(watched_functions_t *self, int i) {
   return 0;
 }
 
-int function_watch_addp_invalidate(watched_functions_t *self, void *addr, size_t size) {
+void function_watch_addp_invalidate(watched_functions_t *self, void *addr, size_t size) {
   function_watch_lock_funcps(self);
 
   for (int i = 0; i < self->funcp_count; i++) {

--- a/elf/symbol_parser.c
+++ b/elf/symbol_parser.c
@@ -237,7 +237,8 @@ void function_watch_try_addp(watched_functions_t *self, char *name, void *addr) 
 
   for (int i = 0; i < self->func_count; i++) {
     if (strcmp(name, self->funcs[i].name) == 0) {
-      function_watch_addp(self, &self->funcs[i], addr);
+      int ret = function_watch_addp(self, &self->funcs[i], addr);
+      assert(ret == 0);
     }
   }
 
@@ -267,15 +268,21 @@ int function_watch_delete_addp(watched_functions_t *self, int i) {
   return 0;
 }
 
-void function_watch_addp_invalidate(watched_functions_t *self, void *addr, size_t size) {
+int function_watch_addp_invalidate(watched_functions_t *self, void *addr, size_t size) {
+  int ret = -1;
+
   function_watch_lock_funcps(self);
 
   for (int i = 0; i < self->funcp_count; i++) {
     if (self->funcps[i].addr >= addr && self->funcps[i].addr < (addr + size)) {
-      function_watch_delete_addp(self, i);
+      ret = function_watch_delete_addp(self, i);
+      assert(ret == 0);
     }
   }
+
   function_watch_unlock_funcps(self);
+
+  return ret;
 }
 
 int function_watch_parse_elf(watched_functions_t *self, Elf *elf, void *base_addr) {

--- a/plugins/memcheck/memcheck.c
+++ b/plugins/memcheck/memcheck.c
@@ -86,8 +86,9 @@ void memcheck_print_error(void *addr, uintptr_t meta, void *pc, stack_frame_t *f
   }
 
   fprintf(stderr, "==memcheck==  Backtrace:\n");
-  get_backtrace(frame, &print_backtrace, NULL);
-  
+  ret = get_backtrace(frame, &print_backtrace, NULL);
+  assert(ret == 0);
+
   fprintf(stderr, "\n");
 }
 


### PR DESCRIPTION
This PR changes the return type of the some functions and check for a return value.

Change return type from `int` to `void` (they do not return any value):
 * `elf_loader.c`, `elf_loader.h`:
   * function `load_elf.c`
* `symbol_parser.c`:
  *  `function_watch_init`, `function_watch_try_addp`, `function_watch_addp_invalidate`

Add return type and check returned value:

* `hash_table.c`:
  * `__mambo_ht_resize`: add `retrun 0` statement at the end of the function
  * `mambo_ht_add_nolock`: check value returned by `__mambo_ht_resize`

Closes #68 #67 #70 #72