### PR TITLE
RISC-V Inline Hash Lookup

### DIFF
--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -611,7 +611,7 @@ void riscv_inline_hash_lookup(dbm_thread *thread_data, uint16_t **write_p,
    *        **  |   addi    a1, rs, offset      |   a1 = rs + offset
    *        ##  |   li      rd, ret_addr        |   ret_addr is 2 or 4
    *            |   li      a0, &hash_table     |
-   *            |   li      x_tmp, HASH_MASK<<1 |   HASH_MASK = 0x7FFFF
+   *            |   li      x_tmp, HASH_MASK<<HT_SHIFT  HASH_MASK = 0x7FFFF
    *        *   |   and     x_tmp, x_tmp, rs    |
    *            |   c.slli  x_tmp, 3            |   sll 3 + sll 1 (from mask)
    *            |   c.add   a0, x_tmp           |     = sll 4 for 16 byte
@@ -667,11 +667,12 @@ void riscv_inline_hash_lookup(dbm_thread *thread_data, uint16_t **write_p,
   // li a0, &hash_table
   riscv_copy_to_reg_64bits(write_p, a0, (uint64_t)&thread_data->entry_address.entries);
 
-  // li x_tmp, HASH_MASK << 1
-  /* Hash mask shifted here because of the 16 bit alignment making the least 
-   * segnificant bit always 0.
+  // li x_tmp, HASH_MASK << HT_SHIFT
+  /* Hash mask shifted here because of the natural alignment making the two least
+   * segnificant bits always 0, or only the least segnificant bit if compressed
+   * instructions are supported.
    */
-  riscv_copy_to_reg_32bits(write_p, x_tmp, CODE_CACHE_HASH_SIZE << 1);
+  riscv_copy_to_reg_32bits(write_p, x_tmp, CODE_CACHE_HASH_SIZE << HT_SHIFT);
   // and x_tmp, x_tmp, rs
   riscv_and(write_p, x_tmp, x_tmp, x_spc);
   *write_p += 2;

--- a/elf/elf_loader.c
+++ b/elf/elf_loader.c
@@ -398,7 +398,18 @@ void elf_run(uintptr_t entry_address, char *filename, int argc, char **argv, cha
 
       case AT_ENTRY:
         d_aux->a_un.a_val = auxv->at_entry;
-        break;  
+        break;
+
+      case AT_L1I_CACHESIZE:
+      case AT_L1I_CACHEGEOMETRY:
+      case AT_L1D_CACHESIZE:
+      case AT_L1D_CACHEGEOMETRY:
+      case AT_L2_CACHESIZE:
+      case AT_L2_CACHEGEOMETRY:
+      case AT_L3_CACHESIZE:
+      case AT_L3_CACHEGEOMETRY:
+        // Ignore
+        break;
 
       default:
         #ifdef __arm__

--- a/scanner_common.h
+++ b/scanner_common.h
@@ -96,6 +96,8 @@ int riscv_branch_helper(uint16_t **o_write_p, uintptr_t target, int const rs1,
                         int const rs2, enum branch_condition const condition);
 int riscv_jalr_helper(uint16_t **o_write_p, uintptr_t target, enum reg rd, enum reg rs1);
 int riscv_jal_helper(uint16_t **o_write_p, uintptr_t target, enum reg rd);
+void riscv_inline_hash_lookup(dbm_thread *thread_data, uint16_t **write_p,
+  int basic_block, enum reg rd, enum reg rs, uint32_t offset, uintptr_t ret_addr);
 #endif
 
 extern void inline_hash_lookup();


### PR DESCRIPTION
Added Inline Hash Lookup optimization to the RISC-V port.

It is based on the IHL routine for AArch64.

### Benchmarks on RISC-V:
Relative performance compared to execution without MAMBO (_ref_):

| | ref | dbm | dbm + IHL |
|:---|:---|:---|:---|
| Primes (exection time) | 1 | 1.04 | 1.03 |
| GCC (exection time) | 1 | 1.04 | 1.03 |
| SHA1 (exection time) | 1 | 12.70 | 1.27 |
| CoreMark (score) | 1 | 13.52 | 1.34 |