### PR TITLE
RISC-V LR/SC Translation

### DIFF
--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -885,22 +885,27 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
            * Translate to
            *          +-------------------------------+
            *          |   lw      x, 0(y)             |
-           *          |   c.mv    t6, x               |   Save original x in t6 for
-           *          +-------------------------------+       comparison when SC
-           * // TODO: Don't just hope that t6 is unused!
+           *          |   addi    sp, sp, -8          |
+           *          |   sd      tmp_reg, 0(sp)      |
+           *          |   li      tmp_reg, &thread_data
+           *          |   sw      x, 8(tmp_reg)       |   atomic_scratch_reg at
+           *          |   ld      tmp_reg, 0(sp)      |     &thread_data + 8
+           *          |   addi    sp, sp, 8           |
+           *          +-------------------------------+
            */
           unsigned int aq, rl, x, y;
 
           riscv_lr_w_decode_fields(read_address, &aq, &rl, &x, &y);
           riscv_lw(&write_p, x, y, 0);
           write_p += 2;
-#ifdef __riscv_compressed
-          riscv_c_mv(&write_p, t6, x);
-          write_p++;
-#else
-          riscv_add(&write_p, t6, x, zero);
+
+          enum reg tmp_reg = x == t1 ? t2 : t1;
+          riscv_push(&write_p, 1 << tmp_reg);
+          riscv_copy_to_reg(&write_p, tmp_reg, (uintptr_t)thread_data);
+          riscv_sw(&write_p, x, tmp_reg, 0, 8);
           write_p += 2;
-#endif
+
+          riscv_pop(&write_p, 1 << tmp_reg);
           break;
         }
         case RISCV_SC_W: { // SC.W -> store-conditional word
@@ -912,21 +917,47 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
            * 
            * Translate to
            *          +-------------------------------+
-           *          |   lr.w    x, (z)n             |
-           *          |   bne     x, t6, .+8          |   Ignore sc as if it fails.
-           *          |   sc.w    x, y, (z)           |       Branch to lr is expected
-           *          +-------------------------------+       to follow.
-           * // TODO: Don't just hope that t6 is unused!
+           *          |   addi    sp, sp, -8          |
+           *          |   sd      tmp_reg, 0(sp)      |
+           *          |   li      tmp_reg, &thread_data
+           *          |   lw      tmp_reg, 8(tmp_reg) |   atomic_scratch_reg at
+           *          |   lr.w    x, (z)              |     &thread_data + 8
+           *          |   bne     x, tmp_reg, .+12    |
+           *          |   sc.w    x, y, (z)           |
+           *          |   jal     zero, .+8           |
+           *          |   addi    x, x, 1             |   Non-zero value indicating
+           *          |   ld      tmp_reg, 0(sp)      |     unsuccessful sc
+           *          |   addi    sp, sp, 8           |
+           *          +-------------------------------+
            */
           unsigned int aq, rl, x, z, y;
-          riscv_instruction follow_inst = riscv_decode(read_address + 2);
+          enum reg tmp_reg;
 
           riscv_sc_w_decode_fields(read_address, &aq, &rl, &x, &y, &z);
+          
+          // Find temporary register
+          for (enum reg t = t3; t <= t6; t++) {
+            if (t != x && t != y && t != z) {
+              tmp_reg = t;
+              break;
+            }
+          }
+          
+          riscv_push(&write_p, 1 << tmp_reg);
+          riscv_copy_to_reg(&write_p, tmp_reg, (uintptr_t)thread_data);
+          riscv_lw(&write_p, tmp_reg, tmp_reg, 8);
+          write_p += 2;
+
           riscv_lr_w(&write_p, 1, 1, x, z);
           write_p += 2;
-          riscv_bne(&write_p, x, t6, 0, 8);
+          riscv_bne(&write_p, x, tmp_reg, 0, 12);
           write_p += 2;
           copy_riscv();
+          riscv_jal_helper(&write_p, (uintptr_t)write_p + 8, zero);
+          riscv_addi(&write_p, x, zero, 1);
+          write_p += 2;
+
+          riscv_pop(&write_p, 1 << tmp_reg);
           break;
         }
         case RISCV_AMOSWAP_W:
@@ -951,22 +982,27 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
            * Translate to
            *          +-------------------------------+
            *          |   ld      x, 0(y)             |
-           *          |   c.mv    t6, x               |   Save original x in t6 for
-           *          +-------------------------------+       comparison when SC
-           * // TODO: Don't just hope that t6 is unused!
+           *          |   addi    sp, sp, -8          |
+           *          |   sd      tmp_reg, 0(sp)      |
+           *          |   li      tmp_reg, &thread_data
+           *          |   sd      x, 8(tmp_reg)       |   atomic_scratch_reg at
+           *          |   ld      tmp_reg, 0(sp)      |     &thread_data + 8
+           *          |   addi    sp, sp, 8           |
+           *          +-------------------------------+
            */
           unsigned int aq, rl, x, y;
 
           riscv_lr_d_decode_fields(read_address, &aq, &rl, &x, &y);
           riscv_ld(&write_p, x, y, 0);
           write_p += 2;
-#ifdef __riscv_compressed
-          riscv_c_mv(&write_p, t6, x);
-          write_p++;
-#else
-          riscv_add(&write_p, t6, x, zero);
+
+          enum reg tmp_reg = x == t1 ? t2 : t1;
+          riscv_push(&write_p, 1 << tmp_reg);
+          riscv_copy_to_reg(&write_p, tmp_reg, (uintptr_t)thread_data);
+          riscv_sd(&write_p, x, tmp_reg, 0, 8);
           write_p += 2;
-#endif
+          
+          riscv_pop(&write_p, 1 << tmp_reg);
           break;
         }
         case RISCV_SC_D: { // SC.D -> store-conditional double word
@@ -978,21 +1014,47 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
            * 
            * Translate to
            *          +-------------------------------+
-           *          |   lr.d    x, (z)n             |
-           *          |   bne     x, t6, .+8          |   Ignore sc as if it fails.
-           *          |   sc.d    x, y, (z)           |       Branch to lr is expected
-           *          +-------------------------------+       to follow.
-           * // TODO: Don't just hope that t6 is unused!
+           *          |   addi    sp, sp, -8          |
+           *          |   sd      tmp_reg, 0(sp)      |
+           *          |   li      tmp_reg, &thread_data
+           *          |   ld      tmp_reg, 8(tmp_reg) |   atomic_scratch_reg at
+           *          |   lr.d    x, (z)              |     &thread_data + 8
+           *          |   bne     x, tmp_reg, .+12    |
+           *          |   sc.d    x, y, (z)           |
+           *          |   jal     zero, .+8           |
+           *          |   addi    x, x, 1             |   Non-zero value indicating
+           *          |   ld      tmp_reg, 0(sp)      |     unsuccessful sc
+           *          |   addi    sp, sp, 8           |
+           *          +-------------------------------+
            */
           unsigned int aq, rl, x, z, y;
-          riscv_instruction follow_inst = riscv_decode(read_address + 2);
+          enum reg tmp_reg;
 
           riscv_sc_d_decode_fields(read_address, &aq, &rl, &x, &y, &z);
+          
+          // Find temporary register
+          for (enum reg t = t3; t <= t6; t++) {
+            if (t != x && t != y && t != z) {
+              tmp_reg = t;
+              break;
+            }
+          }
+          
+          riscv_push(&write_p, 1 << tmp_reg);
+          riscv_copy_to_reg(&write_p, tmp_reg, (uintptr_t)thread_data);
+          riscv_ld(&write_p, tmp_reg, tmp_reg, 8);
+          write_p += 2;
+
           riscv_lr_d(&write_p, 1, 1, x, z);
           write_p += 2;
-          riscv_bne(&write_p, x, t6, 0, 8);
+          riscv_bne(&write_p, x, tmp_reg, 0, 12);
           write_p += 2;
           copy_riscv();
+          riscv_jal_helper(&write_p, (uintptr_t)write_p + 8, zero);
+          riscv_addi(&write_p, x, zero, 1);
+          write_p += 2;
+
+          riscv_pop(&write_p, 1 << tmp_reg);
           break;
         }
         case RISCV_AMOSWAP_D:

--- a/dbm.h
+++ b/dbm.h
@@ -217,6 +217,7 @@ typedef struct dbm_thread_s dbm_thread;
 struct dbm_thread_s {
 #ifdef __riscv
   uintptr_t mambo_tp;
+  uintptr_t atomic_scratch_reg;
 #endif
   dbm_thread *next_thread;
   enum dbm_thread_status status;

--- a/elf/elf_loader.c
+++ b/elf/elf_loader.c
@@ -398,7 +398,18 @@ void elf_run(uintptr_t entry_address, char *filename, int argc, char **argv, cha
 
       case AT_ENTRY:
         d_aux->a_un.a_val = auxv->at_entry;
-        break;  
+        break;
+
+      case AT_L1I_CACHESIZE:
+      case AT_L1I_CACHEGEOMETRY:
+      case AT_L1D_CACHESIZE:
+      case AT_L1D_CACHEGEOMETRY:
+      case AT_L2_CACHESIZE:
+      case AT_L2_CACHEGEOMETRY:
+      case AT_L3_CACHESIZE:
+      case AT_L3_CACHEGEOMETRY:
+        // Ignore
+        break;
 
       default:
         #ifdef __arm__


### PR DESCRIPTION
In contrast to ARM, an LR/SC sequence (code between LR and SC) is very limited on RISC-V platforms. A maximum number of 16 instructions and only a part of the base "I" and "C" instruction set is permitted. Since additional loads and stores are also excluded, instrumenting an instruction inside the sequence will most likely turn it into an "unconstrained LR/SC loop" resulting in the trailing SC to always fail on our test device. The ISA only guaranties for "constrained LR/SC loops" to succeed eventually.

The way unconstrained LR/SC loops are handled is considered a hardware implementation detail. On a SiFive U54, unconstrained LR/SC loops will never succeed, resulting in deadlocks in some cases.

The Approach to fix this issue is to translate the LR/SC sequence to a mixture of a software emulated and hardware atomic sequence. The following figure hopefully gives you an idea of how it works:
![Screenshot from 2022-03-24 16-10-39](https://user-images.githubusercontent.com/16451370/159952449-6759b5fa-9719-45ba-b397-8e58031b735e.png)

The actual implementation stores the value of register `x` into the `dbm_thread` structure and only uses one temporary scratch register. The ordering flags `aq` and `rl` were not considered in the software emulation part (`LR` replaced by `LD`) which may lead to side effects (we did not encounter any side effects).

### Benchmarks
In terms of performance, under certain circumstances the translation introduces quite a bit of overhead at the moment:

| | ref | dbm | dbm + Atomic Translation |
|:---|:---|:---|:---|
| Primes (exection time) | 1 | 1.04 | 1.04 |
| GCC (exection time) | 1 | 1.03 | 1.04 |
| SHA1 (exection time) | 1 | 5.88 | 12.76 |
| CoreMark (score) | 1 | 13.66 | 13.52 |