### PR TITLE
Fix compiling with O0

### DIFF
--- a/common.h
+++ b/common.h
@@ -106,7 +106,7 @@ static inline uintptr_t align_higher(uintptr_t address, uintptr_t alignment) {
   return aligned_address;
 }
 
-inline bool is_offset_within_range(intptr_t const offset, intptr_t const range) {
+static inline bool is_offset_within_range(intptr_t const offset, intptr_t const range) {
   return ((offset <= (range - 4)) && (offset >= (- range)));
 }
 #endif

--- a/dbm.c
+++ b/dbm.c
@@ -97,7 +97,7 @@ uintptr_t cc_lookup(dbm_thread *thread_data, uintptr_t target) {
   return adjust_cc_entry(addr);
 }
 
-inline uintptr_t _lookup_or_scan(dbm_thread * const thread_data,
+static inline uintptr_t _lookup_or_scan(dbm_thread * const thread_data,
                                  const uintptr_t target,
                                  bool * const cached) {
   debug("Thread_data: %p\n", thread_data);


### PR DESCRIPTION
Added ```static``` to two inline function so now MAMBO can be compiled with ```-O0``` optimisation.