### PR TITLE
A32: v8.2 instructions

### DIFF
--- a/arch/aarch32/scanner_a32.c
+++ b/arch/aarch32/scanner_a32.c
@@ -1845,6 +1845,20 @@ size_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block
       case ARM_NEON_VRADDHN:
       case ARM_VFP_VSQRT:
       case ARM_VFP_VSUB_F:
+      case ARM_VFP_VINS_HP:
+      case ARM_VFP_VFMAL_EL:
+      case ARM_VFP_VFMAL_VEC:
+      case ARM_VFP_VFMSL_EL:
+      case ARM_VFP_VFMSL_VEC:
+      case ARM_VFP_VMOV_HP:
+      case ARM_VFP_VMOVX_HP:
+      case ARM_NEON_VSDOT_EL:
+      case ARM_NEON_VSDOT_VEC:
+      case ARM_NEON_VSUDOT_EL:
+      case ARM_NEON_VUDOT_EL:
+      case ARM_NEON_VUDOT_VEC:
+      case ARM_NEON_VUSDOT_EL:
+      case ARM_NEON_VUSDOT_VEC:
         copy_arm();
         break;
 

--- a/arch/aarch32/scanner_t32.c
+++ b/arch/aarch32/scanner_t32.c
@@ -3090,6 +3090,20 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
       case THUMB_VFP_VPUSH:
       case THUMB_VFP_VSQRT:
       case THUMB_VFP_VSUB:
+      case THUMB_VFP_VINS_HP:
+      case THUMB_VFP_VFMAL_EL:
+      case THUMB_VFP_VFMAL_VEC:
+      case THUMB_VFP_VFMSL_EL:
+      case THUMB_VFP_VFMSL_VEC:
+      case THUMB_VFP_VMOV_HP:
+      case THUMB_VFP_VMOVX_HP:
+      case THUMB_NEON_VSDOT_EL:
+      case THUMB_NEON_VSDOT_VEC:
+      case THUMB_NEON_VSUDOT_EL:
+      case THUMB_NEON_VUDOT_EL:
+      case THUMB_NEON_VUDOT_VEC:
+      case THUMB_NEON_VUSDOT_EL:
+      case THUMB_NEON_VUSDOT_VEC:
         copy_thumb_32();
         it_cond_handled = true;
         break;


### PR DESCRIPTION
Aarch32 instructions are now handled in the A32 and T32 scanners.