### PR TITLE
RISC-V Contiguous Traces

### DIFF
--- a/dbm.h
+++ b/dbm.h
@@ -187,6 +187,10 @@ struct trace_exits {
 #ifdef __aarch64__
   int fragment_id;
 #endif
+#ifdef __riscv
+  int fragment_id;
+  uint32_t exit_condition;
+#endif
 };
 
 #ifdef __riscv


### PR DESCRIPTION
This pull request adds Contiguous Traces on top of regular RISC-V traces. This is an optimisation which reduces the critical path size and results in an average ~2.5% performance improvement over regular traces when running the SPEC CPU 2006.