### PR TITLE
Add assertion of ctx->thread_data to mambo_get_thread_id

### DIFF
--- a/api/plugin_support.c
+++ b/api/plugin_support.c
@@ -230,6 +230,7 @@ void mambo_set_cc_addr(mambo_context *ctx, void *addr) {
 }
 
 int mambo_get_thread_id(mambo_context *ctx) {
+  assert(ctx->thread_data != NULL);
   return ctx->thread_data->tid;
 }
 


### PR DESCRIPTION
When in the constructor of plugins, if we call **mambo_get_thread_id** before **mambo_register_plugin**, it will cause a segmentation fault. So we added an assertion to **ctx**. Furthermore, if we call **mambo_get_thread_id** right after **mambo_register_plugin** while in the constructor, no thread is initialised yet which will also cause a segmentation fault due to **ctx->thread_data** being **NULL**.