### PR TITLE
Add parent TID to dbm_thread

### DIFF
--- a/api/plugin_support.c
+++ b/api/plugin_support.c
@@ -234,6 +234,11 @@ int mambo_get_thread_id(mambo_context *ctx) {
   return ctx->thread_data->tid;
 }
 
+int mambo_get_parent_thread_id(mambo_context *ctx) {
+  assert(ctx->thread_data != NULL);
+  return ctx->thread_data->parent_tid;
+}
+
 mambo_cond mambo_get_cond(mambo_context *ctx) {
   return ctx->code.cond;
 }

--- a/api/plugin_support.h
+++ b/api/plugin_support.h
@@ -193,6 +193,7 @@ int mambo_set_source_addr(mambo_context *ctx, void *source_addr);
 void *mambo_get_cc_addr(mambo_context *ctx);
 void mambo_set_cc_addr(mambo_context *ctx, void *addr);
 int mambo_get_thread_id(mambo_context *ctx);
+int mambo_get_parent_thread_id(mambo_context *ctx);
 bool mambo_is_cond(mambo_context *ctx);
 mambo_cond mambo_get_cond(mambo_context *ctx);
 mambo_cond mambo_get_inverted_cond(mambo_context *ctx, mambo_cond cond);

--- a/dbm.h
+++ b/dbm.h
@@ -263,6 +263,7 @@ struct dbm_thread_s {
 #endif
   void *clone_ret_addr;
   pid_t tid;
+  pid_t parent_tid;
   volatile pid_t *set_tid;
   sys_clone_args *clone_args;
   bool clone_vm;

--- a/syscalls.c
+++ b/syscalls.c
@@ -118,6 +118,7 @@ dbm_thread *dbm_create_thread(dbm_thread *thread_data, void *next_inst, sys_clon
   }
   init_thread(new_thread_data);
   new_thread_data->clone_ret_addr = next_inst;
+  new_thread_data->parent_tid = thread_data->tid;
   new_thread_data->set_tid = set_tid;
   new_thread_data->clone_args = args;
 


### PR DESCRIPTION
Add a `parent_tid` to the `dbm_thread` structure. This value will be NULL for the initial thread.


There is currently no easy way to link a parent thread and child thread within a plugin. 

This is useful for finding events for when a parent creates a child and when the child joins back.
For example if Thread1 and Thread2 create a new thread each simultaneously, which new thread belongs to which parent?