### PR TITLE
clone3 handling for ARM and RISC-V

### DIFF
--- a/dbm.h
+++ b/dbm.h
@@ -269,6 +269,7 @@ struct dbm_thread_s {
   bool clone_vm;
   int pending_signals[_NSIG];
   uint32_t is_signal_pending;
+  void *pstack;
 };
 
 typedef enum {
@@ -348,7 +349,11 @@ extern void trace_head_incr();
 extern void* start_of_dispatcher_s;
 extern void* end_of_dispatcher_s;
 extern void th_to_arm();
+#ifdef __riscv
+extern void th_enter(void *stack, uintptr_t cc_addr, uintptr_t tls);
+#else
 extern void th_enter(void *stack, uintptr_t cc_addr);
+#endif
 extern void send_self_signal();
 extern void syscall_wrapper_svc();
 

--- a/util.S
+++ b/util.S
@@ -94,13 +94,13 @@ th_enter:
   LDR X28,      [SP, #208]
   LDP X29, X30, [SP, #224]
   LDP  X2,  X3, [SP], #240
-
   BR X1
 #endif
 
 #ifdef __riscv
 th_enter:
   mv sp, a0
+  mv tp, a2 // contains the pointer to tls which is needed by tp
   ld a2,  0(sp)
   ld a3,  8(sp)
   ld a4,  16(sp)
@@ -129,7 +129,6 @@ th_enter:
   ld s0,  208(sp)
   ld s1,  216(sp)
   addi sp, sp, 224
-  mv tp, a3 // a3 contains the pointer to tls which is needed by tp
   jr a1
 #endif
 .endfunc


### PR DESCRIPTION
This commit adds handling for the clone3 syscall

Where clone takes all parameters as arguments, clone3 accepts arguments packaged in a struct clone_args. As a result, handling differs from clone handling since we first need to unpack clone_args into mambo's struct sys_clone_args.

IMPORTANT: the child stack pointer passed to clone points to the bottom of the child stack. The child stack pointer passed to clone3 points to the top of the child stack and needs to be manually set to point to the bottom of the stack.