### PR TITLE
Add initial support for AT_RSEQ_*

### DIFF
--- a/elf/elf_loader.c
+++ b/elf/elf_loader.c
@@ -377,6 +377,18 @@ void elf_run(uintptr_t entry_address, char *filename, int argc, char **argv, cha
         d_aux->a_un.a_val = s_aux->a_un.a_val;
         break;
 
+#ifdef AT_RSEQ_FEATURE_SIZE
+      case AT_RSEQ_FEATURE_SIZE:
+#endif
+#ifdef AT_RSEQ_ALIGN
+      case AT_RSEQ_ALIGN:
+#endif
+#if defined(AT_RSEQ_FEATURE_SIZE) || defined(AT_RSEQ_ALIGN)
+        fprintf(stderr, "MAMBO: AT_RSEQ_* found! Repeatable sequences (rseq) are not currently supported!\n");
+        d_aux->a_un.a_val = s_aux->a_un.a_val;
+        break;
+#endif
+
       case AT_RANDOM: {
         stack_strings -= 15;
         memcpy(stack_strings, (void *)s_aux->a_un.a_val, 16);


### PR DESCRIPTION
In newer operating systems AT_RSEQ_* parameters are automatically added to binaries. This does not mean that the application uses rseq, but it is a possibility. Currently we do not support rseq as it is a complex issue, so for now we allow AT_RSEQ_* to be passed, however a warning is printed, as there are no guarantees rseq will not be used by the binary. In most of the cases however resq is not used and majority of binaries should run without any issues.

This addresses: https://github.com/beehive-lab/mambo/issues/120