### PR TITLE
Add GitHub Actions to automatically build and run MAMBO for all supported architectures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ run-name: Running GitHub Action
 on: [push]
 jobs:
   build-and-run-mambo:
+    strategy:
+      matrix:
+        os: [focal]
+        arch: [ {os: arm64, qemu: aarch64}, {os: riscv64, qemu: riscv64}, {os: armhf, qemu: arm} ]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -10,13 +15,13 @@ jobs:
           path: mambo
           submodules: true
       - run: sudo apt-get update
-      # - run: sudo apt-get upgrade
+      - run: sudo apt-get upgrade
       - run: sudo apt-get install -y debootstrap
       - run: sudo apt-get install -y qemu-user-static
       - run: mkdir -p /tmp/chroot/
-      - run: sudo debootstrap --arch=riscv64 --foreign focal /tmp/chroot/riscv64 http://ports.ubuntu.com/ubuntu-ports
-      - run: sudo cp /usr/bin/qemu-riscv64-static /tmp/chroot/riscv64/usr/bin/
-      - run: sudo chroot /tmp/chroot/riscv64/ /usr/bin/qemu-riscv64-static /bin/bash -c '/debootstrap/debootstrap --second-stage'
-      - run: sudo cp -r $GITHUB_WORKSPACE/mambo /tmp/chroot/riscv64/root
-      - run: sudo chroot /tmp/chroot/riscv64/ /usr/bin/qemu-riscv64-static /bin/bash -c 'sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get -y install build-essential libelf-dev ruby; cd /root/mambo/; make'
-      - run: sudo chroot /tmp/chroot/riscv64/ /usr/bin/qemu-riscv64-static /bin/bash -c '/root/mambo/dbm /bin/ls'
+      - run: sudo debootstrap --arch=${{ matrix.arch.os }} --foreign ${{ matrix.os }} /tmp/chroot/${{ matrix.arch.os }} http://ports.ubuntu.com/ubuntu-ports
+      - run: sudo cp /usr/bin/qemu-${{ matrix.arch.qemu }}-static /tmp/chroot/${{ matrix.arch.os }}/usr/bin/
+      - run: sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c '/debootstrap/debootstrap --second-stage'
+      - run: sudo cp -r $GITHUB_WORKSPACE/mambo /tmp/chroot/${{ matrix.arch.os }}/root
+      - run: sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c 'sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get -y install build-essential libelf-dev ruby; cd /root/mambo/; make'
+      - run: sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c '/root/mambo/dbm /bin/ls'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,33 @@ jobs:
         with:
           path: mambo
           submodules: true
-      - run: sudo apt-get update
-      - run: sudo apt-get upgrade
-      - run: sudo apt-get install -y debootstrap
-      - run: sudo apt-get install -y qemu-user-static
-      - run: mkdir -p /tmp/chroot/
-      - run: sudo debootstrap --arch=${{ matrix.arch.os }} --foreign ${{ matrix.os }} /tmp/chroot/${{ matrix.arch.os }} http://ports.ubuntu.com/ubuntu-ports
-      - run: sudo cp /usr/bin/qemu-${{ matrix.arch.qemu }}-static /tmp/chroot/${{ matrix.arch.os }}/usr/bin/
-      - run: sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c '/debootstrap/debootstrap --second-stage'
-      - run: sudo cp -r $GITHUB_WORKSPACE/mambo /tmp/chroot/${{ matrix.arch.os }}/root
-      - run: sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c 'sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get -y install build-essential libelf-dev ruby; cd /root/mambo/; make'
-      - run: sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c '/root/mambo/dbm /bin/ls'
+      - name: Set up host environment
+        run: |
+          sudo apt-get update
+          sudo apt-get upgrade
+          sudo apt-get install -y debootstrap
+          sudo apt-get install -y qemu-user-static
+          sudo mkdir -p /tmp/chroot/
+          sudo chown root /bin/tar
+          sudo chmod u+s /bin/tar
+      - uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: /tmp/chroot/${{ matrix.arch.os }}
+          key: ${{ matrix.os }}.${{ matrix.arch.os }}
+      - name: Install and configure sysroot
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: | 
+          sudo debootstrap --arch=${{ matrix.arch.os }} --foreign ${{ matrix.os }} /tmp/chroot/${{ matrix.arch.os }} http://ports.ubuntu.com/ubuntu-ports
+          sudo cp /usr/bin/qemu-${{ matrix.arch.qemu }}-static /tmp/chroot/${{ matrix.arch.os }}/usr/bin/
+          sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c '/debootstrap/debootstrap --second-stage'
+      - uses: actions/cache/save@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/chroot/${{ matrix.arch.os }}
+          key: ${{ matrix.os }}.${{ matrix.arch.os }}
+      - name: Build and run MAMBO inside chroot
+        run: |
+          sudo cp -r $GITHUB_WORKSPACE/mambo /tmp/chroot/${{ matrix.arch.os }}/root
+          sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c 'sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get -y install build-essential libelf-dev ruby; cd /root/mambo/; make'
+          sudo chroot /tmp/chroot/${{ matrix.arch.os }}/ /usr/bin/qemu-${{ matrix.arch.qemu }}-static /bin/bash -c '/root/mambo/dbm /bin/ls'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: build-and-run-mambo
-run-name: Running GitHub Action
-on: [push]
+run-name: Building and running MAMBO triggered by ${{ github.actor }} on ${{ github.ref }}
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize, reopened] 
 jobs:
   build-and-run-mambo:
     strategy:
@@ -8,7 +12,7 @@ jobs:
         os: [focal]
         arch: [ {os: arm64, qemu: aarch64}, {os: riscv64, qemu: riscv64}, {os: armhf, qemu: arm} ]
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: build-and-run-mambo
+run-name: Running GitHub Action
+on: [push]
+jobs:
+  build-and-run-mambo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: mambo
+          submodules: true
+      - run: sudo apt-get update
+      # - run: sudo apt-get upgrade
+      - run: sudo apt-get install -y debootstrap
+      - run: sudo apt-get install -y qemu-user-static
+      - run: mkdir -p /tmp/chroot/
+      - run: sudo debootstrap --arch=riscv64 --foreign focal /tmp/chroot/riscv64 http://ports.ubuntu.com/ubuntu-ports
+      - run: sudo cp /usr/bin/qemu-riscv64-static /tmp/chroot/riscv64/usr/bin/
+      - run: sudo chroot /tmp/chroot/riscv64/ /usr/bin/qemu-riscv64-static /bin/bash -c '/debootstrap/debootstrap --second-stage'
+      - run: sudo cp -r $GITHUB_WORKSPACE/mambo /tmp/chroot/riscv64/root
+      - run: sudo chroot /tmp/chroot/riscv64/ /usr/bin/qemu-riscv64-static /bin/bash -c 'sudo apt-get update; sudo apt-get upgrade -y; sudo apt-get -y install build-essential libelf-dev ruby; cd /root/mambo/; make'
+      - run: sudo chroot /tmp/chroot/riscv64/ /usr/bin/qemu-riscv64-static /bin/bash -c '/root/mambo/dbm /bin/ls'


### PR DESCRIPTION
This pull request adds GitHub actions workflow that automatically (on every push to master, and opened and updated PR) builds MAMBO (using chroot and QEMU) on ARM32, ARM64 and RISCV64 on Ubuntu 20.04, and runs /bin/ls. I tried to enable Ubuntu 22.04 and 18.04, but had some issue with chroot, so that's something to look into in the future. Also, more extensive testing would be nice to have, but having MAMBO build and run is a good starting point.

Currently ARM32 builds fails, but it seems to be unrelated to the automation, and rather a problem with MAMBO itself.