### PR TITLE
Fix incorrect instructions names in ARM32 scanners

### DIFF
--- a/arch/aarch32/scanner_a32.c
+++ b/arch/aarch32/scanner_a32.c
@@ -1804,8 +1804,8 @@ size_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block
       case ARM_NEON_VRSHR:
       case ARM_NEON_VRSHRN:
       case ARM_NEON_VRSRA:
-      case ARM_NEON_VSDOT_EL:
-      case ARM_NEON_VSDOT_VEC:
+      case ARM_NEON_VSDOT_SCAL:
+      case ARM_NEON_VSDOT:
       case ARM_NEON_VSHL:
       case ARM_NEON_VSHLI:
       case ARM_NEON_VSHLL:
@@ -1818,14 +1818,14 @@ size_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block
       case ARM_NEON_VSUB_I:
       case ARM_NEON_VSUBL:
       case ARM_NEON_VSUBW:
-      case ARM_NEON_VSUDOT_EL:
+      case ARM_NEON_VSUDOT:
       case ARM_NEON_VSWP:
       case ARM_NEON_VTRN:
       case ARM_NEON_VTST:
-      case ARM_NEON_VUDOT_EL:
-      case ARM_NEON_VUDOT_VEC:
-      case ARM_NEON_VUSDOT_EL:
-      case ARM_NEON_VUSDOT_VEC:
+      case ARM_NEON_VUDOT_SCAL:
+      case ARM_NEON_VUDOT:
+      case ARM_NEON_VUSDOT_SCAL:
+      case ARM_NEON_VUSDOT:
       case ARM_NEON_VUZP:
       case ARM_NEON_VZIP:
       case ARM_VFP_VABS:
@@ -1839,19 +1839,19 @@ size_t scan_a32(dbm_thread *thread_data, uint32_t *read_address, int basic_block
       case ARM_VFP_VCVT_F_I:
       case ARM_VFP_VDIV:
       case ARM_VFP_VFMA:
-      case ARM_VFP_VFMAL_EL:
-      case ARM_VFP_VFMAL_VEC:
+      case ARM_NEON_VFMAL_SCAL:
+      case ARM_NEON_VFMAL:
       case ARM_VFP_VFMS:
-      case ARM_VFP_VFMSL_EL:
-      case ARM_VFP_VFMSL_VEC:
+      case ARM_NEON_VFMSL_SCAL:
+      case ARM_NEON_VFMSL:
       case ARM_VFP_VFNMS:
-      case ARM_VFP_VINS_HP:
+      case ARM_VFP_VINS:
       case ARM_VFP_VMLA_F:
       case ARM_VFP_VMLS_F:
       case ARM_VFP_VMOV:
       case ARM_VFP_VMOV_HP:
       case ARM_VFP_VMOVI:
-      case ARM_VFP_VMOVX_HP:
+      case ARM_VFP_VMOVX:
       case ARM_VFP_VMRS:
       case ARM_VFP_VMUL_F:
       case ARM_VFP_VNEG:

--- a/arch/aarch32/scanner_t32.c
+++ b/arch/aarch32/scanner_t32.c
@@ -3059,8 +3059,8 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
       case THUMB_NEON_VRHADD:
       case THUMB_NEON_VRSHR:
       case THUMB_NEON_VRSHRN:
-      case THUMB_NEON_VSDOT_EL:
-      case THUMB_NEON_VSDOT_VEC:
+      case THUMB_NEON_VSDOT_SCAL:
+      case THUMB_NEON_VSDOT:
       case THUMB_NEON_VSHL:
       case THUMB_NEON_VSHLI:
       case THUMB_NEON_VSHLL:
@@ -3070,14 +3070,14 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
       case THUMB_NEON_VSUB_I:
       case THUMB_NEON_VSUBL:
       case THUMB_NEON_VSUBW:
-      case THUMB_NEON_VSUDOT_EL:
+      case THUMB_NEON_VSUDOT:
       case THUMB_NEON_VSWP:
       case THUMB_NEON_VTRN:
       case THUMB_NEON_VTST:
-      case THUMB_NEON_VUDOT_EL:
-      case THUMB_NEON_VUDOT_VEC:
-      case THUMB_NEON_VUSDOT_EL:
-      case THUMB_NEON_VUSDOT_VEC:
+      case THUMB_NEON_VUDOT_SCAL:
+      case THUMB_NEON_VUDOT:
+      case THUMB_NEON_VUSDOT_SCAL:
+      case THUMB_NEON_VUSDOT:
       case THUMB_VFP_VABS:
       case THUMB_VFP_VADD:
       case THUMB_VFP_VCMP:
@@ -3088,17 +3088,17 @@ size_t scan_t32(dbm_thread *thread_data, uint16_t *read_address, int basic_block
       case THUMB_VFP_VCVT_F_FP:
       case THUMB_VFP_VCVT_F_I:
       case THUMB_VFP_VDIV:
-      case THUMB_VFP_VFMAL_EL:
-      case THUMB_VFP_VFMAL_VEC:
-      case THUMB_VFP_VFMSL_EL:
-      case THUMB_VFP_VFMSL_VEC:
-      case THUMB_VFP_VINS_HP:
+      case THUMB_NEON_VFMAL_SCAL:
+      case THUMB_NEON_VFMAL:
+      case THUMB_NEON_VFMSL_SCAL:
+      case THUMB_NEON_VFMSL:
+      case THUMB_VFP_VINS:
       case THUMB_VFP_VMLA_F:
       case THUMB_VFP_VMLS_F:
       case THUMB_VFP_VMOV:
       case THUMB_VFP_VMOV_HP:
       case THUMB_VFP_VMOVI:
-      case THUMB_VFP_VMOVX_HP:
+      case THUMB_VFP_VMOVX:
       case THUMB_VFP_VMRS: // rt=0xF is CPSR
       case THUMB_VFP_VMUL:
       case THUMB_VFP_VNEG:

--- a/dbm.h
+++ b/dbm.h
@@ -69,7 +69,11 @@
 #define MAX_CC_LINKS 100000
 
 // The size of the initial data segment allocation for brk emulation
-#define RESERVED_BRK_SPACE (128*(PAGE_SIZE))
+#ifdef __arm__
+  #define RESERVED_BRK_SPACE (PAGE_SIZE)
+#else
+  #define RESERVED_BRK_SPACE (128*(PAGE_SIZE))
+#endif
 
 #if defined __arm__ || __aarch64__ 
 #define THUMB 0x1


### PR DESCRIPTION
For unknown reasons some of the NEON instructions has been updated in the PIE arm and thumb definitions without reflecting those changes in the aarch32 scanners. As a result MAMBO does not compile for 32-bit architectures. This commit adjusts the names in the scanner to match definitions in PIE.