### PR TITLE
Update Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Build
 
 Prerequisites: an ARM or RISC-V64GC system (physical or virtual) to build and run MAMBO on; dependencies: gcc toolchain, libelf(-dev), ruby (>=1.9.1). Debian or Ubuntu users can install the required packages with `sudo apt-get install build-essential libelf-dev ruby`.
 
-    git clone --recurse-submodules https://github.com/beehive-lab/mambo.git
+    git clone https://github.com/beehive-lab/mambo.git
     cd mambo
     make
 


### PR DESCRIPTION
Update build instructions to reflect the fact that pie is no longer in a separate repo