### PR TITLE
Basic support for RISCV vector instructions

### DIFF
--- a/arch/riscv/scanner_riscv.c
+++ b/arch/riscv/scanner_riscv.c
@@ -1290,6 +1290,16 @@ size_t scan_riscv(dbm_thread *thread_data, uint16_t *read_address,
         case RISCV_FCVT_D_L:
         case RISCV_FCVT_D_LU:
         case RISCV_FMV_D_X:
+	// RV64V
+	case RISCV_V_ARITH_GENERIC:
+	case RISCV_V_LOAD_1:
+	case RISCV_V_LOAD_2:
+	case RISCV_V_LOAD_3:
+	case RISCV_V_LOAD_4:
+	case RISCV_V_STORE_1:
+	case RISCV_V_STORE_2:
+	case RISCV_V_STORE_3:
+	case RISCV_V_STORE_4:
           copy_riscv();
           break;
 #endif

--- a/makefile
+++ b/makefile
@@ -12,6 +12,7 @@
 #PLUGINS+=plugins/hotspot.c
 #PLUGINS+=plugins/datarace/datarace.c plugins/datarace/detectors/fasttrack.c
 #PLUGINS+=plugins/datarace/datarace.c plugins/datarace/detectors/djit.c
+#PLUGINS+=plugins/vector_counter.c
 
 OPTS= -DDBM_LINK_UNCOND_IMM
 OPTS+=-DDBM_INLINE_UNCOND_IMM
@@ -30,7 +31,7 @@ CFLAGS+=-D_GNU_SOURCE -g -std=gnu99 -O2 -Wunused-variable
 CFLAGS+=-DVERSION=\"$(VERSION)\"
 
 LDFLAGS+=-static -ldl
-LIBS=-lelf -lpthread -lz
+LIBS=-lelf -lpthread -lz -lzstd
 HEADERS=*.h makefile
 INCLUDES=-I/usr/include/libelf -I.
 SOURCES= common.c dbm.c traces.c syscalls.c dispatcher.c util.S traces_common.c

--- a/pie/riscv.txt
+++ b/pie/riscv.txt
@@ -274,6 +274,17 @@ fmv_x_d          11100010 0000aaaa a000bbbb b1010011, b:rd, a:f_rs1
 fcvt_d_l         11010010 0010aaaa abbbcccc c1010011, c:f_rd, a:rs1, b:rm
 fcvt_d_lu        11010010 0011aaaa abbbcccc c1010011, c:f_rd, a:rs1, b:rm
 fmv_d_x          11110010 0000aaaa a000bbbb b1010011, b:f_rd, a:rs1
+#
+# RV64V Standard Extension for Vector Operations -- RV64V 1.0 Ratified
+v_arith_generic   aaaaaabc ccccdddd deeeffff f1010111, a:funct6, b:vm, c:vs2, d:vs1, e:funct3, f:vd
+v_load_1          aaabccde eeeeffff f000gggg g0000111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_load_2          aaabccde eeeeffff f101gggg g0000111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_load_3          aaabccde eeeeffff f110gggg g0000111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_load_4          aaabccde eeeeffff f111gggg g0000111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_store_1         aaabccde eeeeffff f000gggg g0100111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_store_2         aaabccde eeeeffff f101gggg g0100111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_store_3         aaabccde eeeeffff f110gggg g0100111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
+v_store_4         aaabccde eeeeffff f111gggg g0100111, a:nf, b:mew, c:mop, d:vm, e:v2, f:rs1, g:vd
 
 #
 # Generic instruction types

--- a/plugins/vector_counter.c
+++ b/plugins/vector_counter.c
@@ -1,0 +1,56 @@
+// Counts how many vector instructions are executed at runtime
+
+#include <stdio.h>
+
+#include "plugins.h"
+
+static inline bool rvv_is_vector_word(uint32_t insn) {
+    uint32_t opcode = insn & 0x7F;
+    uint32_t funct3 = (insn >> 12) & 0x7;
+
+    switch (opcode) {
+    case 0x57:
+        return true;
+
+    case 0x07:
+    case 0x27:
+        switch (funct3) {
+        // get all vector encodings under LOAD-FP/STORE-FP opcodes
+        case 0b000:
+        case 0b101:
+        case 0b110:
+        case 0b111:
+            return true;
+        default:
+            return false;
+        }
+
+    default:
+        return false;
+    }
+}
+
+bool mambo_is_vector(mambo_context *ctx) {
+    uint32_t insn = *(uint32_t *)ctx->code.read_address;
+    return rvv_is_vector_word(insn);
+}
+
+static uint64_t vector_inst_count = 0;
+
+static int vector_pre_inst_cb(mambo_context *ctx) {
+    if (!mambo_is_vector(ctx))
+        return 0;
+    emit_counter64_incr(ctx, &vector_inst_count, 1);
+    return 0;
+}
+
+__attribute__((constructor)) static void vector_counter_init(void) {
+    mambo_context *ctx = mambo_register_plugin();
+    mambo_register_pre_inst_cb(ctx, &vector_pre_inst_cb);
+}
+
+// Prints count at exit
+__attribute__((destructor)) static void vector_counter_fini(void) {
+    fprintf(stderr, "[vector_counter] total vector instructions executed: %" PRIu64 "\n",
+            vector_inst_count);
+}


### PR DESCRIPTION
This PR adds basic support for RISC-V Vector instructions to the existing RISC-V backend.

Since there are no RISC-V Vector instructions that alter the control flow of a program this is quite straightforward. The only thing adapted in this PR is the scanner and the generator and the scanner to be able to handle vector instructions as regular non-control-flow instructions. 
Right now the recognition for vector instructions is not very fine grained, but I could still change this if you think it is needed. 

Additionally, to test this I added a plugin that counts the number of vector instructions executed in a program.